### PR TITLE
[shopfloor] pack transfer refactoring

### DIFF
--- a/shopfloor/actions/pack_transfer_validate.py
+++ b/shopfloor/actions/pack_transfer_validate.py
@@ -1,6 +1,7 @@
 from odoo.addons.component.core import Component
 
 
+# TODO remove
 # TODO think BETTER about how we want to share the common methods / workflows
 class PackTransferValidateAction(Component):
     """Pack Transfer shared business logic

--- a/shopfloor/services/schema.py
+++ b/shopfloor/services/schema.py
@@ -118,3 +118,13 @@ class BaseShopfloorSchemaResponse(Component):
             "move_line_count": {"required": True, "type": "integer"},
             "weight": {"required": True, "nullable": True, "type": "float"},
         }
+
+    def package_level(self):
+        return {
+            "id": {"required": True, "type": "integer"},
+            "name": {"type": "string", "nullable": False, "required": True},
+            "location_src": {"type": "dict", "schema": self.location()},
+            "location_dest": {"type": "dict", "schema": self.location()},
+            "product": {"type": "dict", "schema": self.product()},
+            "picking": {"type": "dict", "schema": self.picking()},
+        }

--- a/shopfloor/services/single_pack_putaway.py
+++ b/shopfloor/services/single_pack_putaway.py
@@ -3,6 +3,9 @@ from odoo import _
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 
+# NOTE a lot of code is duplicated with SinglePackTransfer, but
+# this service will be replaced
+
 
 class SinglePackPutaway(Component):
     """Methods for the Single Pack Put-Away Process"""

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -7,9 +7,6 @@ class SinglePackTransferCase(CommonCase):
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super().setUpClass(*args, **kwargs)
-        cls.product_a = cls.env["product.product"].create(
-            {"name": "Product A", "type": "product"}
-        )
         cls.pack_a = cls.env["stock.quant.package"].create(
             {"location_id": cls.stock_location.id}
         )
@@ -60,6 +57,29 @@ class SinglePackTransferCase(CommonCase):
         package_level.is_done = True
         return package_level
 
+    def _response_package_level_data(self, package_level):
+        return {
+            "id": package_level.id,
+            "name": package_level.package_id.name,
+            "location_src": {"id": self.shelf1.id, "name": self.shelf1.name},
+            "location_dest": {"id": self.shelf2.id, "name": self.shelf2.name},
+            "picking": {
+                "id": self.picking.id,
+                "name": self.picking.name,
+                "note": None,
+                "origin": None,
+                "partner": None,
+                "move_line_count": len(self.picking.move_line_ids),
+                "weight": 2.0,
+            },
+            "product": {
+                "id": self.product_a.id,
+                "name": self.product_a.name,
+                "default_code": self.product_a.default_code,
+                "display_name": self.product_a.display_name,
+            },
+        }
+
     def test_start(self):
         """Test the happy path for single pack transfer /start endpoint
 
@@ -92,14 +112,7 @@ class SinglePackTransferCase(CommonCase):
         self.assert_response(
             response,
             next_state="scan_location",
-            data={
-                "id": self.ANY,
-                "name": package_level.package_id.name,
-                "location_src": {"id": self.shelf1.id, "name": self.shelf1.name},
-                "location_dest": {"id": self.shelf2.id, "name": self.shelf2.name},
-                "picking": {"id": self.picking.id, "name": self.picking.name},
-                "product": {"id": self.product_a.id, "name": self.product_a.name},
-            },
+            data=self._response_package_level_data(package_level),
         )
 
     def test_start_no_operation(self):
@@ -315,14 +328,7 @@ class SinglePackTransferCase(CommonCase):
                 "message": "Operation's already running."
                 " Would you like to take it over?",
             },
-            data={
-                "id": self.ANY,
-                "name": package_level.package_id.name,
-                "location_src": {"id": self.shelf1.id, "name": self.shelf1.name},
-                "location_dest": {"id": self.shelf2.id, "name": self.shelf2.name},
-                "picking": {"id": self.picking.id, "name": self.picking.name},
-                "product": {"id": self.product_a.id, "name": self.product_a.name},
-            },
+            data=self._response_package_level_data(package_level),
         )
 
     def test_validate(self):
@@ -556,14 +562,7 @@ class SinglePackTransferCase(CommonCase):
             response,
             next_state="confirm_location",
             message=message,
-            data={
-                "id": self.ANY,
-                "name": package_level.package_id.name,
-                "location_src": {"id": self.shelf1.id, "name": self.shelf1.name},
-                "location_dest": {"id": self.shelf2.id, "name": self.shelf2.name},
-                "picking": {"id": self.picking.id, "name": self.picking.name},
-                "product": {"id": self.product_a.id, "name": self.product_a.name},
-            },
+            data=self._response_package_level_data(package_level),
         )
 
     def test_validate_location_with_confirm(self):

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -270,7 +270,8 @@ export var ScenarioBaseMixin = {
     },
 };
 
-// TODO: move it to a specific file maybe
+// TODO: move it back it the transfer scenario when we get rid of
+// the putaway scenario
 export var SinglePackStatesMixin = {
     data: function() {
         return {

--- a/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
@@ -15,7 +15,7 @@ export var SinglePackTransfer = Vue.component("single-pack-transfer", {
             <searchbar v-if="state_is(initial_state_key)" v-on:found="on_scan" :input_placeholder="search_input_placeholder"></searchbar>
             <searchbar v-if="state_is('scan_location')" v-on:found="on_scan" :input_placeholder="search_input_placeholder" :input_data_type="'location'"></searchbar>
             <user-confirmation v-if="need_confirmation" v-on:user-confirmation="on_user_confirm" v-bind:question="user_notification.message"></user-confirmation>
-            <detail-operation v-if="state.key != initial_state_key" :record="state.data" />
+            <detail-operation v-if="state.key != initial_state_key && state.key != 'show_completion_info'" :record="state.data" />
             <last-operation v-if="state_is('show_completion_info')" v-on:confirm="state.on_confirm"></last-operation>
             <cancel-button v-on:cancel="on_cancel" v-if="show_cancel_button"></cancel-button>
         </Screen>


### PR DESCRIPTION
* use the generic data structures and schema
* review the method parameters, variable names
* use `_response_for_<state>` pattern (as done in newer scenarii, easier to read)
* fix a bug with the completion info screen in frontend

Note: after https://github.com/camptocamp/wms/pull/11 is implemented, we'll have
to replace the completion info screen by the modal popup