### PR TITLE
cluster picking: implement change package/lot

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -141,6 +141,18 @@ class MessageAction(Component):
             ),
         }
 
+    def no_lot_for_barcode(self, barcode):
+        return {
+            "message_type": "error",
+            "body": _("No lot found for {}".format(barcode)),
+        }
+
+    def lot_on_wrong_product(self, barcode):
+        return {
+            "message_type": "error",
+            "body": _("Lot {} is for another product.").format(barcode),
+        }
+
     def several_lots_in_location(self, location):
         return {
             "message_type": "warning",
@@ -165,6 +177,12 @@ class MessageAction(Component):
         return {
             "message_type": "error",
             "body": _("Unrecoverable error, please restart."),
+        }
+
+    def package_different_content(self, package):
+        return {
+            "message_type": "error",
+            "body": _("Package {} has a different content.").format(package.name),
         }
 
     def x_units_put_in_package(self, qty, product, package):

--- a/shopfloor/models/__init__.py
+++ b/shopfloor/models/__init__.py
@@ -3,6 +3,7 @@ from . import stock_picking_type
 from . import shopfloor_profile
 from . import stock_location
 from . import stock_move_line
+from . import stock_package_level
 from . import stock_picking
 from . import stock_picking_batch
 from . import stock_quant_package

--- a/shopfloor/models/stock_package_level.py
+++ b/shopfloor/models/stock_package_level.py
@@ -1,0 +1,28 @@
+from odoo import models
+
+
+class StockPackageLevel(models.Model):
+    _inherit = "stock.package_level"
+
+    def replace_package(self, new_package):
+        """Replace a package on an assigned package level and related records
+
+        The replacement package must have the same properties (same products
+        and quantities).
+        """
+        if self.state not in ("new", "assigned"):
+            return
+
+        move_lines = self.move_line_ids
+        # the write method on stock.move.line updates the reservation on quants
+        move_lines.package_id = new_package
+        # when a package is set on a line, the destination package is the same
+        # by default
+        move_lines.result_package_id = new_package
+        for quant in new_package.quant_ids:
+            for line in move_lines:
+                if line.product_id == quant.product_id:
+                    line.lot_id = quant.lot_id
+                    line.owner_id = quant.owner_id
+
+        self.package_id = new_package

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -113,6 +113,13 @@ class ClusterPicking(Component):
             )
         return self._response(next_state="scan_destination", data=data, message=message)
 
+    def _response_for_change_pack_lot(self, move_line, message=None):
+        return self._response(
+            next_state="change_pack_lot",
+            data=self._data_move_line(move_line),
+            message=message,
+        )
+
     def _response_for_zero_check(self, move_line):
         data = {
             "id": move_line.id,
@@ -876,9 +883,195 @@ class ClusterPicking(Component):
 
         Transitions:
         * scan_destination: the pack or the lot could be changed
-        * start_line: any error occurred during the change
+        * change_pack_lot: any error occurred during the change
         """
-        return self._response()
+        move_line = self.env["stock.move.line"].browse(move_line_id)
+        if not move_line.exists():
+            return self._response(
+                next_state="start", message=self.msg_store.unrecoverable_error()
+            )
+        search = self.actions_for("search")
+        lot = search.lot_from_scan(barcode)
+        if lot:
+            # If the lot is part of a package, what we really want
+            # is not to change the lot, but change the package (which will
+            # in turn change the lot altogether), but we have to pay attention
+            # to some things:
+            # * cannot replace a package by a lot without package (qty may be
+            #   different, ...)
+            # * if we have several packages for the same lot, we can't know which
+            #   one the operator is moving, ask to scan a package
+            lot_package_quants = self.env["stock.quant"].search(
+                [
+                    ("lot_id", "=", lot.id),
+                    ("location_id", "=", move_line.location_id.id),
+                    ("package_id", "!=", False),
+                    ("quantity", ">", 0),
+                ]
+            )
+            if move_line.package_id and not lot_package_quants:
+                return self._response_for_change_pack_lot(
+                    move_line,
+                    message={
+                        "message_type": "error",
+                        "body": _("Lot {} is not a package.").format(lot.name),
+                    },
+                )
+
+            if len(lot_package_quants) == 1:
+                package = lot_package_quants.package_id
+                return self._change_pack_lot_change_package(move_line, package)
+            elif len(lot_package_quants) > 1:
+                return self._response_for_change_pack_lot(
+                    move_line,
+                    message=self.msg_store.several_packs_in_location(
+                        move_line.location_id
+                    ),
+                )
+
+            return self._change_pack_lot_change_lot(move_line, lot)
+
+        package = search.package_from_scan(barcode)
+        if package:
+            return self._change_pack_lot_change_package(move_line, package)
+
+        return self._response_for_change_pack_lot(
+            move_line,
+            message={
+                "message_type": "warning",
+                "body": _("No package or lot found for barcode {}").format(barcode),
+            },
+        )
+
+    def _change_pack_lot_change_lot(self, move_line, lot):
+        inventory = self.actions_for("inventory")
+        product = move_line.product_id
+        if lot.product_id != product:
+            return self._response_for_change_pack_lot(
+                move_line, message=self.msg_store.lot_on_wrong_product(lot.name)
+            )
+        previous_lot = move_line.lot_id
+        # Changing the lot on the move line updates the reservation
+        # on the quants
+        move_line.lot_id = lot
+
+        success_body = _("Lot {} replaced by lot {}.").format(
+            previous_lot.name, lot.name
+        )
+        # check that we are supposed to have enough of this lot in the
+        # source location
+        quant = lot.quant_ids.filtered(lambda q: q.location_id == move_line.location_id)
+        if not quant:
+            # not supposed to have this lot here... (if there is a quant
+            # but not enough quantity we don't care here: user will report
+            # a stock issue)
+            inventory.create_control_stock(
+                move_line.location_id,
+                move_line.product_id,
+                move_line.package_id,
+                move_line.lot_id,
+                _("Pick: stock issue on lot: {} found in {}").format(
+                    lot.name, move_line.location_id.name
+                ),
+            )
+            success_body += _(" A draft inventory has been created for control.")
+
+        return self._response_for_scan_destination(
+            move_line, message={"message_type": "info", "body": success_body}
+        )
+
+    def _package_identical_move_lines_qty(self, package, move_lines):
+        grouped_quants = {}
+        for quant in package.quant_ids:
+            grouped_quants.setdefault(quant.product_id, 0)
+            grouped_quants[quant.product_id] += quant.quantity
+
+        grouped_lines = {}
+        for move_line in move_lines:
+            grouped_lines.setdefault(move_line.product_id, 0)
+            grouped_lines[move_line.product_id] += move_line.product_uom_qty
+
+        return grouped_quants == grouped_lines
+
+    def _change_pack_lot_change_package(self, move_line, package):
+        inventory = self.actions_for("inventory")
+
+        package_level = move_line.package_level_id
+        # several move lines can be moved by the package level, we'll have
+        # to update all of them
+        move_lines = package_level.move_line_ids
+
+        # prevent to replace a package by a package with a different content
+        identical_content = self._package_identical_move_lines_qty(package, move_lines)
+        if not identical_content:
+            return self._response_for_change_pack_lot(
+                move_line, message=self.msg_store.package_different_content(package)
+            )
+
+        previous_package = move_line.package_id
+
+        if package.location_id != move_line.location_id:
+            # the package has been scanned in the current location so we know its
+            # a mistake in the data... fix the quant to move the package here
+            inventory.move_package_quants_to_location(package, move_line.location_id)
+
+        # search a package level which would already move the scanned package
+        reserved_level = (
+            self.env["stock.package_level"].search([("package_id", "=", package.id)])
+            # not possible to search on state
+            .filtered(lambda level: level.state in ("new", "assigned"))
+        )
+        if reserved_level:
+            reserved_level.ensure_one()
+        if reserved_level.is_done:
+            # Not really supposed to happen: if someone sets is_done, the package
+            # should no longer be here! But we have to check this and inform the
+            # user in any case.
+            return self._response_for_change_pack_lot(
+                move_line,
+                message={
+                    "message_type": "error",
+                    "body": _(
+                        "Package {} cannot be picked, already moved by transfer {}"
+                    ).format(package.name, reserved_level.picking_id.name),
+                },
+            )
+
+        # Switch the package with the level which was moving it, as we know
+        # that:
+        # * only one package level at a time is supposed to move a package
+        # * the content of the other package is the same (as we checked the
+        #   content is the same as the current move lines)
+        # * if we left the reserved level with the scanned package, we would
+        #   have 2 levels for the same package and odoo would unreserve the
+        #   move lines as soon as we confirm the current moves
+        # Considering this, we should be safe to interchange the packages
+        if reserved_level:
+            # Ignore updates on quant reservation, which would prevent to switch
+            # 2 packages between 2 assigned package levels: when writing the
+            # package of the second level to the first level, it would unreserve
+            # it because the second level is still using the package.
+            # But here, we know they both available before and must be available after!
+            reserved_level.with_context(bypass_reservation_update=True).replace_package(
+                previous_package
+            )
+            package_level.with_context(bypass_reservation_update=True).replace_package(
+                package
+            )
+        else:
+            # when we are not switching packages, we expect the quant
+            # reservations to be aligned
+            package_level.replace_package(package)
+
+        return self._response_for_scan_destination(
+            move_line,
+            message={
+                "message_type": "info",
+                "body": _("Package {} replaced by package {}").format(
+                    previous_package.name, package.name
+                ),
+            },
+        )
 
     def set_destination_all(self, picking_batch_id, barcode, confirmation=False):
         """Set the destination for all the lines of the batch with a dest. package
@@ -1202,6 +1395,7 @@ class ShopfloorClusterPickingValidatorResponse(Component):
             "unload_single": self._schema_for_unload_single,
             "unload_set_destination": self._schema_for_unload_single,
             "confirm_unload_set_destination": self._schema_for_unload_single,
+            "change_pack_lot": self._schema_for_single_line_details,
         }
 
     def find_batch(self):
@@ -1296,7 +1490,9 @@ class ShopfloorClusterPickingValidatorResponse(Component):
         )
 
     def change_pack_lot(self):
-        return self._response_schema(next_states={"scan_destination", "start_line"})
+        return self._response_schema(
+            next_states={"change_pack_lot", "scan_destination"}
+        )
 
     def set_destination_all(self):
         return self._response_schema(

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -771,9 +771,9 @@ class ClusterPicking(Component):
             )
         # flag as postponed
         move_line.shopfloor_postponed = True
-        return self._response_for_skip_line(move_line)
+        return self._pick_after_skip_line(move_line)
 
-    def _response_for_skip_line(self, move_line):
+    def _pick_after_skip_line(self, move_line):
         batch = move_line.picking_id.batch_id
         return self._pick_next_line(batch)
 

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -12,6 +12,7 @@ from . import test_cluster_picking_select
 from . import test_cluster_picking_scan
 from . import test_cluster_picking_skip
 from . import test_cluster_picking_stock_issue
+from . import test_cluster_picking_change_pack_lot
 from . import test_cluster_picking_unload
 from . import test_checkout_base
 from . import test_checkout_scan

--- a/shopfloor/tests/test_cluster_picking_change_pack_lot.py
+++ b/shopfloor/tests/test_cluster_picking_change_pack_lot.py
@@ -1,0 +1,535 @@
+from collections import namedtuple
+
+from odoo.tests.common import Form
+
+from .test_cluster_picking_base import ClusterPickingCommonCase
+
+
+class ClusterPickingChangePackLotCommon(ClusterPickingCommonCase):
+
+    # used by _create_package_in_location
+    PackageContent = namedtuple(
+        "PackageContent",
+        # recordset of the product,
+        # quantity in float
+        # recordset of the lot (optional)
+        "product quantity lot",
+    )
+
+    def _create_package_in_location(self, location, content):
+        """Create a package and quants in a location
+
+        content is a list of PackageContent
+        """
+        package = self.env["stock.quant.package"].create({})
+        for product, quantity, lot in content:
+            self._update_qty_in_location(
+                location, product, quantity, package=package, lot=lot
+            )
+        return package
+
+    def _create_lot(self, product):
+        return self.env["stock.production.lot"].create(
+            {"product_id": product.id, "company_id": self.env.company.id}
+        )
+
+    def _test_change_pack_lot(self, line, barcode, success=True, message=None):
+        response = self.service.dispatch(
+            "change_pack_lot", params={"move_line_id": line.id, "barcode": barcode},
+        )
+        if success:
+            self.assert_response(
+                response,
+                message=message,
+                next_state="scan_destination",
+                data=self._line_data(line),
+            )
+        else:
+            self.assert_response(
+                response,
+                message=message,
+                next_state="change_pack_lot",
+                data=self._line_data(line),
+            )
+
+    def _skip_line(self, line, next_line=None):
+        response = self.service.dispatch("skip_line", params={"move_line_id": line.id})
+        if next_line:
+            self.assert_response(
+                response, next_state="start_line", data=self._line_data(next_line)
+            )
+        return response
+
+    def assert_quant_reserved_qty(self, move_line, qty_func, package=None, lot=None):
+        domain = [
+            ("location_id", "=", move_line.location_id.id),
+            ("product_id", "=", move_line.product_id.id),
+        ]
+        if package:
+            domain.append(("package_id", "=", package.id))
+        if lot:
+            domain.append(("lot_id", "=", lot.id))
+        quant = self.env["stock.quant"].search(domain)
+        self.assertEqual(quant.reserved_quantity, qty_func())
+
+    def assert_quant_package_qty(self, location, package, qty_func):
+        quant = self.env["stock.quant"].search(
+            [("location_id", "=", location.id), ("package_id", "=", package.id)]
+        )
+        self.assertEqual(quant.quantity, qty_func())
+
+    def assert_control_stock_inventory(self, location, product, lot):
+        inventory = self.env["stock.inventory"].search([], order="id desc", limit=1)
+        self.assertRecordValues(
+            inventory,
+            [
+                {
+                    "state": "draft",
+                    "product_ids": product.ids,
+                    "name": "Pick: stock issue on lot: {} found in {}".format(
+                        lot.name, location.name
+                    ),
+                },
+            ],
+        )
+
+
+class ClusterPickingChangePackLotCase(ClusterPickingChangePackLotCommon):
+    """Tests covering the /change_pack_lot endpoint"""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super().setUpClass(*args, **kwargs)
+        cls.batch = cls._create_picking_batch(
+            [[cls.BatchProduct(product=cls.product_a, quantity=10)]]
+        )
+
+    def test_change_pack_lot_change_pack_ok(self):
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+
+        # ensure we have our new package in the same location
+        new_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        line = self.batch.picking_ids.move_line_ids
+        self._test_change_pack_lot(
+            line,
+            new_package.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Package {} replaced by package {}".format(
+                    initial_package.name, new_package.name
+                ),
+            },
+        )
+
+        self.assertRecordValues(
+            line, [{"package_id": new_package.id, "result_package_id": new_package.id}]
+        )
+
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_pack_lot_change_pack_different_location(self):
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        # initial_package from shelf1 will be selected in our move line
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+
+        # put a package in shelf2 in the system, but we assume that in real,
+        # the operator put it in shelf1
+        new_package = self._create_package_in_location(
+            self.shelf2, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        line = self.batch.picking_ids.move_line_ids
+        # when the operator wants to pick the initial package, in shelf1, the new
+        # package is in front of the other so they want to change the package
+        self._test_change_pack_lot(
+            line,
+            new_package.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Package {} replaced by package {}".format(
+                    initial_package.name, new_package.name
+                ),
+            },
+        )
+
+        self.assertRecordValues(
+            line, [{"package_id": new_package.id, "result_package_id": new_package.id}]
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        # check that reservations have been updated
+        self.assert_quant_package_qty(self.shelf2, new_package, lambda: 0)
+        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_pack_lot_change_lot_in_package_ok(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
+        )
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+        # ensure we have our new package in the same location
+        new_lot = self._create_lot(self.product_a)
+        new_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=new_lot)]
+        )
+        line = self.batch.picking_ids.move_line_ids
+        self._test_change_pack_lot(
+            line,
+            new_lot.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Package {} replaced by package {}".format(
+                    initial_package.name, new_package.name
+                ),
+            },
+        )
+
+        self.assertRecordValues(
+            line,
+            [
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "lot_id": new_lot.id,
+                }
+            ],
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_pack_lot_change_lot_in_several_packages_error(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
+        )
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+        line = self.batch.picking_ids.move_line_ids
+        # create 2 packages for the same new lot in the same location
+        new_lot = self._create_lot(self.product_a)
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, new_lot)]
+        )
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, new_lot)]
+        )
+        self._test_change_pack_lot(
+            line,
+            new_lot.name,
+            success=False,
+            message={
+                "message_type": "warning",
+                "body": "Several packages found in {},"
+                " please scan a package.".format(self.shelf1.name),
+            },
+        )
+
+    def test_change_pack_lot_change_lot_from_package_error(self):
+        # we shouldn't be allowed to replace a package by a lot
+        # if the lot is not a package in the quants (because we
+        # could then replace a package by a single unit)
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
+        )
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+        line = self.batch.picking_ids.move_line_ids
+        # create a lot and put a unit in the location without package
+        new_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, line.product_id, 1, lot=new_lot)
+        self._test_change_pack_lot(
+            line,
+            new_lot.name,
+            success=False,
+            message={
+                "message_type": "error",
+                "body": "Lot {} is not a package.".format(new_lot.name),
+            },
+        )
+
+    def test_change_pack_lot_change_lot_ok(self):
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+        line = self.batch.picking_ids.move_line_ids
+        source_location = line.location_id
+        new_lot = self._create_lot(self.product_a)
+        # ensure we have our new package in the same location
+        self._update_qty_in_location(source_location, line.product_id, 10, lot=new_lot)
+        self._test_change_pack_lot(
+            line,
+            new_lot.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Lot {} replaced by lot {}.".format(
+                    initial_lot.name, new_lot.name
+                ),
+            },
+        )
+
+        self.assertRecordValues(line, [{"lot_id": new_lot.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+
+    def test_change_pack_lot_change_lot_different_location_ok(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        self._simulate_batch_selected(self.batch, fill_stock=False)
+        line = self.batch.picking_ids.move_line_ids
+        new_lot = self._create_lot(self.product_a)
+        # ensure we have our new package in a different location
+        self._update_qty_in_location(self.shelf2, line.product_id, 10, lot=new_lot)
+        self._test_change_pack_lot(
+            line,
+            new_lot.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Lot {} replaced by lot {}. A draft inventory has"
+                " been created for control.".format(initial_lot.name, new_lot.name),
+            },
+        )
+
+        self.assertRecordValues(line, [{"lot_id": new_lot.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+        self.assert_control_stock_inventory(self.shelf1, line.product_id, new_lot)
+
+
+class ClusterPickingChangePackLotCaseSpecial(ClusterPickingChangePackLotCommon):
+    """Tests covering the /change_pack_lot endpoint
+
+    Special cases where we use a custom batch transfer
+    """
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super().setUpClass(*args, **kwargs)
+
+    def _create_picking_with_package_level(self, packages):
+        picking_form = Form(self.env["stock.picking"])
+        picking_form.partner_id = self.customer
+        picking_form.origin = "test"
+        picking_form.picking_type_id = self.picking_type
+        picking_form.location_id = self.stock_location
+        picking_form.location_dest_id = self.packing_location
+        for package in packages:
+            with picking_form.package_level_ids_details.new() as move:
+                move.package_id = package
+        picking = picking_form.save()
+        picking.action_confirm()
+        picking.action_assign()
+        return picking
+
+    def _create_batch_with_pickings(self, pickings):
+        batch_form = Form(self.env["stock.picking.batch"])
+        for picking in pickings:
+            batch_form.picking_ids.add(picking)
+        batch = batch_form.save()
+        return batch
+
+    def test_change_pack_lot_change_pack_different_content_error(self):
+        # create the initial package, that will be reserved first
+        initial_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, lot=None),
+                self.PackageContent(self.product_b, 10, lot=None),
+            ],
+        )
+        picking = self._create_picking_with_package_level(initial_package)
+        batch = self._create_batch_with_pickings(picking)
+        self._simulate_batch_selected(batch, fill_stock=False)
+
+        # create a new package in the same location
+        # with a different content
+        new_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, lot=None),
+                self.PackageContent(self.product_b, 8, lot=None),
+            ],
+        )
+
+        lines = batch.picking_ids.move_line_ids
+        # try to use the new package, which has a different content,
+        # not accepted
+        self._test_change_pack_lot(
+            lines[0],
+            new_package.name,
+            success=False,
+            message={
+                "message_type": "error",
+                "body": "Package {} has a different content.".format(new_package.name),
+            },
+        )
+
+    def test_change_pack_lot_change_pack_multi_content_with_lot(self):
+        (self.product_a + self.product_b).tracking = "lot"
+        # create a package with 2 products tracked by lot, stored in shelf1
+        # this package is reserved first on the move line
+        initial_lot_a = self._create_lot(self.product_a)
+        initial_lot_b = self._create_lot(self.product_b)
+        initial_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, initial_lot_a),
+                self.PackageContent(self.product_b, 10, initial_lot_b),
+            ],
+        )
+
+        # create and reserve our transfer using the initial package
+        picking = self._create_picking_with_package_level(initial_package)
+        batch = self._create_batch_with_pickings(picking)
+        self._simulate_batch_selected(batch, fill_stock=False)
+
+        lines = picking.move_line_ids
+        package_level = lines.mapped("package_level_id")
+
+        # create a second package with the same content, which will be used
+        # as replacement
+        new_lot_a = self._create_lot(self.product_a)
+        new_lot_b = self._create_lot(self.product_b)
+        new_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, new_lot_a),
+                self.PackageContent(self.product_b, 10, new_lot_b),
+            ],
+        )
+        # changing the package of the first line will change all of them
+        self._test_change_pack_lot(
+            lines[0],
+            new_package.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Package {} replaced by package {}".format(
+                    initial_package.name, new_package.name
+                ),
+            },
+        )
+
+        self.assertRecordValues(
+            lines,
+            [
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "lot_id": new_lot_a.id,
+                },
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "lot_id": new_lot_b.id,
+                },
+            ],
+        )
+
+        self.assertRecordValues(package_level, [{"package_id": new_package.id}])
+        # check that reservations have been updated
+        for line in lines:
+            self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+            self.assert_quant_reserved_qty(
+                line, lambda: line.product_qty, package=new_package
+            )
+
+    def test_change_pack_lot_change_pack_steal_from_other_move_line(self):
+        # create 2 picking, each with its own package
+        package1 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)],
+        )
+        picking1 = self._create_picking_with_package_level(package1)
+        self.assertEqual(picking1.move_line_ids.package_id, package1)
+
+        package2 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)],
+        )
+        picking2 = self._create_picking_with_package_level(package2)
+        self.assertEqual(picking2.move_line_ids.package_id, package2)
+
+        batch = self._create_batch_with_pickings(picking1 + picking2)
+        self._simulate_batch_selected(batch, fill_stock=False)
+
+        line = picking1.move_line_ids
+        # We "steal" package2 for the picking1
+        self._test_change_pack_lot(
+            line,
+            package2.name,
+            success=True,
+            message={
+                "message_type": "info",
+                "body": "Package {} replaced by package {}".format(
+                    package1.name, package2.name
+                ),
+            },
+        )
+
+        self.assertRecordValues(
+            picking1.move_line_ids,
+            [
+                {
+                    "package_id": package2.id,
+                    "result_package_id": package2.id,
+                    "state": "assigned",
+                }
+            ],
+        )
+        self.assertRecordValues(
+            picking2.move_line_ids,
+            [
+                {
+                    "package_id": package1.id,
+                    "result_package_id": package1.id,
+                    "state": "assigned",
+                }
+            ],
+        )
+        self.assertRecordValues(
+            picking1.package_level_ids,
+            [{"package_id": package2.id, "state": "assigned"}],
+        )
+        self.assertRecordValues(
+            picking2.package_level_ids,
+            [{"package_id": package1.id, "state": "assigned"}],
+        )
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(
+            picking1.move_line_ids,
+            lambda: picking1.move_line_ids.product_qty,
+            package=package2,
+        )
+        self.assert_quant_reserved_qty(
+            picking2.move_line_ids,
+            lambda: picking2.move_line_ids.product_qty,
+            package=package1,
+        )

--- a/shopfloor/tests/test_cluster_picking_skip.py
+++ b/shopfloor/tests/test_cluster_picking_skip.py
@@ -35,8 +35,16 @@ class ClusterPickingSkipLineCase(ClusterPickingCommonCase):
 
     def test_skip_line(self):
         self._simulate_batch_selected(self.batch, in_package=True)
-        lines = self.batch.picking_ids.move_line_ids
-        # 1st line, next is 2nd
+        lines = self.batch.picking_ids.move_line_ids.sorted(
+            lambda line: (
+                line.location_id,
+                line.shopfloor_postponed,
+                line.move_id.sequence,
+                line.move_id.id,
+                line.id,
+            )
+        )
+
         self.assertFalse(lines[0].shopfloor_postponed)
         self._skip_line(lines[0], lines[1])
         self.assertTrue(lines[0].shopfloor_postponed)


### PR DESCRIPTION
Note: include #14 which should be merged first


When an operator picks a move line, they can use a button to replace the
package or the lot.

# Replacing a lot

The lot can be replaced when:

* the move was not moving a package
* or the move was moving a package, but the lot is in a single
  package in the current move line's location

Replacing the lot may lead negative quants if the available quantity
was insuficient, but physically, the quantity was there, so the
situation should balance itself eventually, and when it happens, a draft
inventory is created in the location for a user to check.

# Replacing a package

The package can be replaced when:

* the package content is the same, same products and quantities, but the
  lots can be different
* the package is in another package level with the "is_done" flag, in
  this situation, the package is really not supposed to be here

Some tricky situations may happen:

* Physically, the replacement package is in the move line's location,
  but in the quants, it's elsewhere. It means it's an error in the data,
  and we should not prevent someone to pick it. The quant is updated
  with inventory moves to move the package in the correct location
  before doing the replacement.
* The package is already reserved for another package level (not
  "is_done" yet). The operator may be allowed to choose another identical
  package, in this case, it switches the packages between the 2
  transfers (we know their content is the same, except the lots).
