### PR TITLE
cluster picking: Add picking_batch_id in every method call

### DIFF
--- a/shopfloor/tests/test_cluster_picking_change_pack_lot.py
+++ b/shopfloor/tests/test_cluster_picking_change_pack_lot.py
@@ -34,8 +34,14 @@ class ClusterPickingChangePackLotCommon(ClusterPickingCommonCase):
         )
 
     def _test_change_pack_lot(self, line, barcode, success=True, message=None):
+        batch = line.picking_id.batch_id
         response = self.service.dispatch(
-            "change_pack_lot", params={"move_line_id": line.id, "barcode": barcode},
+            "change_pack_lot",
+            params={
+                "picking_batch_id": batch.id,
+                "move_line_id": line.id,
+                "barcode": barcode,
+            },
         )
         if success:
             self.assert_response(
@@ -53,7 +59,10 @@ class ClusterPickingChangePackLotCommon(ClusterPickingCommonCase):
             )
 
     def _skip_line(self, line, next_line=None):
-        response = self.service.dispatch("skip_line", params={"move_line_id": line.id})
+        batch = line.picking_id.batch_id
+        response = self.service.dispatch(
+            "skip_line", params={"picking_batch_id": batch.id, "move_line_id": line.id}
+        )
         if next_line:
             self.assert_response(
                 response, next_state="start_line", data=self._line_data(next_line)

--- a/shopfloor/tests/test_cluster_picking_scan.py
+++ b/shopfloor/tests/test_cluster_picking_scan.py
@@ -15,16 +15,28 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
     """
 
     def _scan_line_ok(self, line, scanned):
+        batch = line.picking_id.batch_id
         response = self.service.dispatch(
-            "scan_line", params={"move_line_id": line.id, "barcode": scanned}
+            "scan_line",
+            params={
+                "picking_batch_id": batch.id,
+                "move_line_id": line.id,
+                "barcode": scanned,
+            },
         )
         self.assert_response(
             response, next_state="scan_destination", data=self._line_data(line)
         )
 
     def _scan_line_error(self, line, scanned, message):
+        batch = line.picking_id.batch_id
         response = self.service.dispatch(
-            "scan_line", params={"move_line_id": line.id, "barcode": scanned}
+            "scan_line",
+            params={
+                "picking_batch_id": batch.id,
+                "move_line_id": line.id,
+                "barcode": scanned,
+            },
         )
         self.assert_response(
             response,
@@ -300,6 +312,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 "barcode": self.bin1.name,
                 "quantity": qty_done,
@@ -335,6 +348,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 "barcode": self.bin2.name,
                 "quantity": qty_done,
@@ -360,6 +374,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line2.id,
                 # this bin is used for the same picking, should be allowed
                 "barcode": self.bin1.name,
@@ -383,6 +398,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 # this bin is used for the other picking
                 "barcode": self.bin1.name,
@@ -407,6 +423,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 # this bin is used for the other picking
                 "barcode": "⌿",
@@ -429,6 +446,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 "barcode": self.bin1.name,
                 "quantity": line.product_uom_qty + 1,
@@ -455,6 +473,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 "barcode": self.bin1.name,
                 "quantity": line.product_uom_qty - 3,
@@ -495,6 +514,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         response = self.service.dispatch(
             "scan_destination_pack",
             params={
+                "picking_batch_id": self.batch.id,
                 "move_line_id": line.id,
                 "barcode": self.bin1.name,
                 "quantity": line.product_uom_qty,
@@ -504,7 +524,11 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="zero_check",
-            data={"id": line.id, "location_src": self.data.location(line.location_id)},
+            data={
+                "id": line.id,
+                "location_src": self.data.location(line.location_id),
+                "batch": self.data.picking_batch(self.batch),
+            },
         )
 
 
@@ -546,7 +570,12 @@ class ClusterPickingIsZeroCase(ClusterPickingCommonCase):
     def test_is_zero_is_empty(self):
         """call /is_zero confirming it's empty"""
         response = self.service.dispatch(
-            "is_zero", params={"move_line_id": self.line.id, "zero": True}
+            "is_zero",
+            params={
+                "picking_batch_id": self.batch.id,
+                "move_line_id": self.line.id,
+                "zero": True,
+            },
         )
         self.assert_response(
             response,
@@ -565,7 +594,12 @@ class ClusterPickingIsZeroCase(ClusterPickingCommonCase):
     def test_is_zero_is_not_empty(self):
         """call /is_zero not confirming it's empty"""
         response = self.service.dispatch(
-            "is_zero", params={"move_line_id": self.line.id, "zero": False}
+            "is_zero",
+            params={
+                "picking_batch_id": self.batch.id,
+                "move_line_id": self.line.id,
+                "zero": False,
+            },
         )
         inventory = self.env["stock.inventory"].search(
             [

--- a/shopfloor/tests/test_cluster_picking_skip.py
+++ b/shopfloor/tests/test_cluster_picking_skip.py
@@ -26,7 +26,10 @@ class ClusterPickingSkipLineCase(ClusterPickingCommonCase):
         )
 
     def _skip_line(self, line, next_line=None):
-        response = self.service.dispatch("skip_line", params={"move_line_id": line.id})
+        response = self.service.dispatch(
+            "skip_line",
+            params={"picking_batch_id": self.batch.id, "move_line_id": line.id},
+        )
         if next_line:
             self.assert_response(
                 response, next_state="start_line", data=self._line_data(next_line)

--- a/shopfloor/tests/test_cluster_picking_stock_issue.py
+++ b/shopfloor/tests/test_cluster_picking_stock_issue.py
@@ -29,8 +29,10 @@ class ClusterPickingStockIssue(ClusterPickingCommonCase):
         cls.dest_package = cls.env["stock.quant.package"].create({})
 
     def _stock_issue(self, line, next_line_func=None):
+        batch = line.picking_id.batch_id
         response = self.service.dispatch(
-            "stock_issue", params={"move_line_id": line.id}
+            "stock_issue",
+            params={"picking_batch_id": batch.id, "move_line_id": line.id},
         )
         # use a function/lambda to delay the read of the next line,
         # when calling _stock_issue(), the move_line may not exist and

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -193,6 +193,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("scan_line", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                                 barcode: scanned.text,
                             })
@@ -208,6 +209,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_action_skip_line: () => {
                         this.wait_call(
                             this.odoo.call("skip_line", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                             })
                         );
@@ -238,6 +240,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("scan_destination_pack", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                                 barcode: scanned.text,
                                 quantity: this.scan_destination_qty,
@@ -255,6 +258,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_action_confirm_zero: () => {
                         this.wait_call(
                             this.odoo.call("is_zero", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                                 zero: true,
                             })
@@ -263,6 +267,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_action_confirm_not_zero: () => {
                         this.wait_call(
                             this.odoo.call("is_zero", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                                 zero: false,
                             })
@@ -326,6 +331,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("unload_scan_pack", {
+                                picking_batch_id: this.current_batch().id,
                                 package_id: null, // FIXME: where does it come from? backend data?
                                 barcode: scanned.text,
                             })
@@ -340,6 +346,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("unload_scan_destination", {
+                                picking_batch_id: this.current_batch().id,
                                 package_id: null, // FIXME: where does it come from? backend data?
                                 barcode: scanned.text,
                             })
@@ -354,18 +361,10 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("unload_scan_destination", {
+                                picking_batch_id: this.current_batch().id,
                                 package_id: null, // FIXME: where does it come from? backend data?
                                 barcode: scanned.text,
                                 confirmation: true,
-                            })
-                        );
-                    },
-                },
-                show_completion_info: {
-                    on_confirm: () => {
-                        this.wait_call(
-                            this.odoo.call("unload_router", {
-                                picking_batch_id: this.current_batch().id,
                             })
                         );
                     },
@@ -378,6 +377,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("change_pack_lot", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                                 barcode: scanned.text,
                             })
@@ -394,6 +394,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                     on_confirm_stock_issue: () => {
                         this.wait_call(
                             this.odoo.call("stock_issue", {
+                                picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                             })
                         );


### PR DESCRIPTION
So we can always handle a move line deleted on the backend by
taking the next move line of the batch instead of aborting.