### PR TITLE
cluster picking: fix reservation inconsistency

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -601,7 +601,12 @@ class ClusterPicking(Component):
             # contained less items than expected)
             remaining = move_line.product_uom_qty - quantity
             new_line = move_line.copy({"product_uom_qty": remaining, "qty_done": 0})
-            move_line.product_uom_qty = quantity
+            # if we didn't bypass reservation update, the quant reservation
+            # would be reduced as much as the deduced quantity, which is wrong
+            # as we only moved the quantity to a new move line
+            move_line.with_context(
+                bypass_reservation_update=True
+            ).product_uom_qty = quantity
 
         search = self.actions_for("search")
         bin_package = search.package_from_scan(barcode)


### PR DESCRIPTION
When we pick a good and pick less than the reserved quantity,
the endpoint splits the move line in 2 parts: one with the qty_done
set to the quantity passed to the endpoint, another move line for
the remaining.
When the copy of the move line is created, the reserved quantity
on the move line doesn't change, but when the quantity is reduced on
the current line, the reserved quantity on the quant is automatically
reduced accordingly.
We don't want this, because we didn't reduced the total reserved
quantity, only moved it to another move line.

Before:
-------

* We have a quant of 40 product A in Shelf 1
* We reserve a move line of 20 product A in Shelf 1, the reserved
  quantity of the quant is 20
* We start the batch transfer, using the barcode scanner app, we
  scan the product and update the quantity to pick 13 products only
* A new line of 7 is created, quant's reserved quantity is still 20
* Quantity of the current move line is set to 13, the reserved quantity
  of the quant is now 13

Result: we have a desynchronization between the move lines (20 reserved)
and the quants (13 reserved). If we try to unreserve a move line, we
have an error: "It is not possible to unreserve more products of %s than
you have in stock."

After:
------

Same steps as before, but we ignore the update of the quant at the last
step.

Result: both the move lines and quants have 20 units reserved.

card 740