### PR TITLE
Add option to disable zero check in scenario

### DIFF
--- a/shopfloor/demo/stock_picking_type_demo.xml
+++ b/shopfloor/demo/stock_picking_type_demo.xml
@@ -28,6 +28,7 @@
         <field name="code">internal</field>
         <field name="show_operations" eval="1" />
         <field name="display_completion_info" eval="1" />
+        <field name="shopfloor_zero_check" eval="1" />
     </record>
     <record id="picking_type_checkout_demo" model="stock.picking.type">
         <field name="name">Checkout</field>

--- a/shopfloor/models/stock_picking_type.py
+++ b/shopfloor/models/stock_picking_type.py
@@ -7,3 +7,9 @@ class StockPickingType(models.Model):
     shopfloor_menu_ids = fields.Many2many(
         comodel_name="shopfloor.menu", string="Shopfloor Menus", readonly=True,
     )
+    shopfloor_zero_check = fields.Boolean(
+        string="Activate Zero Check",
+        help="For Shopfloor scenarios using it (Cluster Picking, Zone Picking,"
+        " Discrete order Picking), the zero check step will be activated when"
+        " a location becomes empty after a move.",
+    )

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -621,7 +621,8 @@ class ClusterPicking(Component):
             )
         move_line.write({"qty_done": quantity, "result_package_id": bin_package.id})
 
-        if self._planned_qty_in_location_is_empty(
+        zero_check = move_line.picking_id.picking_type_id.shopfloor_zero_check
+        if zero_check and self._planned_qty_in_location_is_empty(
             move_line.product_id, move_line.location_id
         ):
             return self._response_for_zero_check(batch, move_line)

--- a/shopfloor/views/stock_picking_type.xml
+++ b/shopfloor/views/stock_picking_type.xml
@@ -5,9 +5,15 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
-            <field name="warehouse_id" position="after">
-                <field name="shopfloor_menu_ids" widget="many2many_tags" />
-            </field>
+            <xpath expr="//sheet/group[2]" position="inside">
+                <group string="Shopfloor" name="shopfloor">
+                    <field name="shopfloor_menu_ids" widget="many2many_tags" />
+                    <field
+                        name="shopfloor_zero_check"
+                        attrs="{'invisible': [('shopfloor_menu_ids', '=', [])]}"
+                    />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Currently, it applies only for Cluster Picking, it will apply
on Zone Picking and Discrete Order Picking too.

When a location becomes empty and the option is active, the user has
to validate that the location is really empty. It doesn't really make
sense for picking types that move pallets, so they would disable it
there.

There is an ongoing discussion whether this option should be on the
picking type or on the shopfloor menu, it is possible that this option
will be moved.
