### PR TITLE
Add a picking sequence on location

### DIFF
--- a/shopfloor/models/stock_location.py
+++ b/shopfloor/models/stock_location.py
@@ -4,6 +4,11 @@ from odoo import fields, models
 class StockLocation(models.Model):
     _inherit = "stock.location"
 
+    shopfloor_picking_sequence = fields.Integer(
+        string="Shopfloor Picking Sequence",
+        default=0,
+        help="The picking done in Shopfloor scenarios will respect this order.",
+    )
     source_move_line_ids = fields.One2many(
         comodel_name="stock.move.line", inverse_name="location_id", readonly=True
     )

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -321,6 +321,7 @@ class ClusterPicking(Component):
     def _sort_key_lines(line):
         return (
             line.shopfloor_postponed,
+            line.location_id.shopfloor_picking_sequence,
             line.location_id.name,
             line.move_id.sequence,
             line.move_id.id,

--- a/shopfloor/views/stock_location.xml
+++ b/shopfloor/views/stock_location.xml
@@ -10,6 +10,11 @@
                 <label for="barcode" />
                 <field name="barcode" />
             </xpath>
+            <xpath expr="//group[@name='additional_info']/.." position="inside">
+                <group string="Shopfloor">
+                    <field name="shopfloor_picking_sequence" />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
To be used in scenarios to sort the move lines.
Asking by location name may not be accurate for several reasons.
We cannot rely solely on this. Using a sequence guarantees we have
strictly the desired order.
