### PR TITLE
cluster picking: lock all the lines before set destination

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1140,12 +1140,12 @@ class ClusterPicking(Component):
             if not confirmation:
                 return self._response_for_confirm_unload_all(batch)
 
-        self._unload_set_destination_on_lines(lines, scanned_location)
+        self._unload_write_destination_on_lines(lines, scanned_location)
         completion_info = self.actions_for("completion.info")
         completion_info_popup = completion_info.popup(lines)
         return self._unload_end(batch, completion_info_popup=completion_info_popup)
 
-    def _unload_set_destination_on_lines(self, lines, location):
+    def _unload_write_destination_on_lines(self, lines, location):
         lines.write({"shopfloor_unloaded": True, "location_dest_id": location.id})
         for line in lines:
             # We set the picking to done only when the last line is
@@ -1260,6 +1260,20 @@ class ClusterPicking(Component):
         if not lines:
             return self._unload_end(batch)
 
+        return self._unload_scan_destination_lines(
+            batch, package, lines, barcode, confirmation=confirmation
+        )
+
+    def _unload_scan_destination_lock_lines(self, lines):
+        """Lock move lines"""
+        sql = "SELECT id FROM %s WHERE ID IN %%s FOR UPDATE" % lines._table
+        self.env.cr.execute(sql, (tuple(lines.ids),), log_exceptions=False)
+
+    def _unload_scan_destination_lines(
+        self, batch, package, lines, barcode, confirmation=False
+    ):
+        # Lock move lines that will be updated
+        self._unload_scan_destination_lock_lines(lines)
         first_line = fields.first(lines)
         picking_type = fields.first(batch.picking_ids).picking_type_id
         scanned_location = self.actions_for("search").location_from_scan(barcode)
@@ -1278,7 +1292,7 @@ class ClusterPicking(Component):
             if not confirmation:
                 return self._response_for_confirm_unload_set_destination(batch, package)
 
-        self._unload_set_destination_on_lines(lines, scanned_location)
+        self._unload_write_destination_on_lines(lines, scanned_location)
 
         completion_info = self.actions_for("completion.info")
         completion_info_popup = completion_info.popup(lines)

--- a/shopfloor_checkout_sync/services/cluster_picking.py
+++ b/shopfloor_checkout_sync/services/cluster_picking.py
@@ -7,9 +7,25 @@ from odoo.addons.component.core import Component
 class ClusterPicking(Component):
     _inherit = "shopfloor.cluster.picking"
 
-    def _unload_set_destination_on_lines(self, lines, location):
-        self._sync_checkout(lines.mapped("move_id"), location)
-        return super()._unload_set_destination_on_lines(lines, location)
+    def _has_to_sync_destination(self, lines):
+        # we assume that if the destination is already a bin location,
+        # the sync has already been done
+        return any(line.location_dest_id.child_ids for line in lines)
+
+    def _unload_scan_destination_lock_lines(self, lines):
+        if self._has_to_sync_destination(lines):
+            dest_pickings = lines.move_id._moves_to_sync_checkout()
+            all_moves = self.env["stock.move"].union(*dest_pickings.values())
+            # add lock on all the lines that will be synchronized on the
+            # destination so other transactions will wait before trying to
+            # change the destination
+            lines = lines | all_moves.move_line_ids
+        super()._unload_scan_destination_lock_lines(lines)
+
+    def _unload_write_destination_on_lines(self, lines, location):
+        if self._has_to_sync_destination(lines):
+            self._sync_checkout(lines.mapped("move_id"), location)
+        return super()._unload_write_destination_on_lines(lines, location)
 
     def _sync_checkout(self, moves, location):
         dest_pickings = moves._moves_to_sync_checkout()

--- a/shopfloor_checkout_sync/tests/test_shopfloor_sync.py
+++ b/shopfloor_checkout_sync/tests/test_shopfloor_sync.py
@@ -48,7 +48,6 @@ class TestShopfloorCheckoutSync(ClusterPickingUnloadingCommonCase):
     def test_unload_scan_destination_sync_checkout(self):
         """When a destination is set, it applies the sync"""
         self._set_dest_package_and_done(self.move1.move_line_ids, self.bin1)
-
         self.service.dispatch(
             "unload_scan_destination",
             params={


### PR DESCRIPTION
At the beginning of the endpoint that writes the destination of lines
moved by a package, lock them. This is mostly to have an entrypoint for
the module shopfloor_checkout_sync:

In the general scenario, the lines are moved by the same bin package,
they should be moved by the same operator, so we should never have any
concurrency issue.

However, when we use the synchronization of destinations
(shopfloor_checkout_sync), as soon as we scan a destination for the
first line, it updates the destination of all the other move lines
that reach the same operation type for an order, so it might change
the destination of another operator's line. At the beginning of the
endpoint, lock the line to ensure 2 operators won't synchronize
different destinations (I would expect to have a transaction rollback
error and a rollback anyway).