### PR TITLE
Add shopfloor automatic creation of picking batch

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,2 @@
 rest-framework
 server-auth
-stock-logistics-warehouse https://github.com/guewen/stock-logistics-warehouse 13.0-mig-stock_picking_completion_info

--- a/setup/shopfloor_batch_automatic_creation/odoo/addons/shopfloor_batch_automatic_creation
+++ b/setup/shopfloor_batch_automatic_creation/odoo/addons/shopfloor_batch_automatic_creation
@@ -1,0 +1,1 @@
+../../../../shopfloor_batch_automatic_creation

--- a/setup/shopfloor_batch_automatic_creation/setup.py
+++ b/setup/shopfloor_batch_automatic_creation/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -29,6 +29,7 @@ class ShopfloorMenu(models.Model):
         " scanned and no move already exists. Any new move is created in the"
         " selected operation type, so it can be active only when one type is selected.",
     )
+    active = fields.Boolean(default=True)
 
     def _selection_scenario(self):
         return [

--- a/shopfloor/readme/CONTRIBUTORS.rst
+++ b/shopfloor/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
 
   ADD YOURSELF

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -239,7 +239,6 @@ class ClusterPicking(Component):
             "cancel",
         )
 
-    # TODO this may be used in other scenarios? if so, extract
     def _select_a_picking_batch(self, batches):
         # look for in progress + assigned to self first
         candidates = batches.filtered(

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -26,6 +26,47 @@
             </tree>
         </field>
     </record>
+    <record id="shopfloor_menu_form_view" model="ir.ui.view">
+        <field name="name">shopfloor menu form</field>
+        <field name="model">shopfloor.menu</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                    <label for="name" class="oe_edit_only" />
+                    <h1>
+                        <field name="name" />
+                    </h1>
+                    <group name="main">
+                        <field name="active" invisible="1" />
+                        <field name="scenario" />
+                        <field
+                            name="profile_ids"
+                            widget="many2many_tags"
+                            options="{'no_create': 1}"
+                        />
+                        <field
+                            name="picking_type_ids"
+                            widget="many2many_tags"
+                            options="{'no_create': 1}"
+                        />
+                    </group>
+                    <group name="options" string="Scenario Options">
+                        <field name="move_create_is_possible" invisible="1" />
+                        <field
+                            name="allow_move_create"
+                            attrs="{'invisible': [('move_create_is_possible', '=', False)]}"
+                        />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
     <record id="shopfloor_menu_search_view" model="ir.ui.view">
         <field name="name">shopfloor menu search</field>
         <field name="model">shopfloor.menu</field>
@@ -33,8 +74,14 @@
             <search>
                 <field name="name" />
                 <field name="scenario" />
-                <field name="profile_ids" />
                 <field name="picking_type_ids" />
+                <field name="profile_ids" />
+                <separator />
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active', '=', False)]"
+                />
             </search>
         </field>
     </record>
@@ -42,6 +89,6 @@
         <field name="name">Menus</field>
         <field name="res_model">shopfloor.menu</field>
         <field name="type">ir.actions.act_window</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">tree,form</field>
     </record>
 </odoo>

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -57,11 +57,13 @@
                         />
                     </group>
                     <group name="options" string="Scenario Options">
-                        <field name="move_create_is_possible" invisible="1" />
-                        <field
-                            name="allow_move_create"
+                        <group
+                            name="move_create"
                             attrs="{'invisible': [('move_create_is_possible', '=', False)]}"
-                        />
+                        >
+                            <field name="move_create_is_possible" invisible="1" />
+                            <field name="allow_move_create" />
+                        </group>
                     </group>
                 </sheet>
             </form>

--- a/shopfloor_batch_automatic_creation/__init__.py
+++ b/shopfloor_batch_automatic_creation/__init__.py
@@ -1,0 +1,3 @@
+from . import actions
+from . import models
+from . import services

--- a/shopfloor_batch_automatic_creation/__manifest__.py
+++ b/shopfloor_batch_automatic_creation/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Shopfloor - Batch Transfer Automatic Creation",
+    "summary": "Create batch transfers for Cluster Picking",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": True,
+    "depends": [
+        "shopfloor",
+        "stock_packaging_calculator",  # OCA/stock-logistics-warehouse
+        "product_packaging_dimension",  # OCA/stock-logistics-warehouse
+        "product_total_weight_from_packaging",  # OCA/product-attribute
+    ],
+    "data": ["views/shopfloor_menu_views.xml"],
+}

--- a/shopfloor_batch_automatic_creation/actions/__init__.py
+++ b/shopfloor_batch_automatic_creation/actions/__init__.py
@@ -1,0 +1,1 @@
+from . import picking_batch_auto_create

--- a/shopfloor_batch_automatic_creation/actions/picking_batch_auto_create.py
+++ b/shopfloor_batch_automatic_creation/actions/picking_batch_auto_create.py
@@ -1,0 +1,171 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import hashlib
+import logging
+import struct
+
+from odoo import fields, tools
+
+from odoo.addons.component.core import Component
+
+_logger = logging.getLogger(__name__)
+
+
+class PickingBatchAutoCreateAction(Component):
+    """Automatic creation of picking batches"""
+
+    _name = "shopfloor.picking.batch.auto.create"
+    _inherit = "shopfloor.process.action"
+    _usage = "picking.batch.auto.create"
+
+    _advisory_lock_name = "shopfloor_batch_picking_create"
+
+    def create_batch(self, picking_types, max_pickings=0, max_weight=0, max_volume=0):
+        self._lock()
+        pickings = self._search_pickings(picking_types, user=self.env.user)
+        if not pickings:
+            pickings = self._search_pickings(picking_types)
+
+        pickings = self._sort(pickings)
+        pickings = self._apply_limits(pickings, max_pickings, max_weight, max_volume)
+        if not pickings:
+            return self.env["stock.picking.batch"].browse()
+        return self._create_batch(pickings)
+
+    def _lock(self):
+        """Lock to prevent concurrent creation of batch
+
+        Use a blocking advisory lock to prevent 2 transactions to create
+        a batch at the same time. The lock is released at the commit or
+        rollback of the transaction.
+
+        The creation of a new batch should be short enough not to block
+        the users for too long.
+        """
+        _logger.info(
+            "trying to acquire lock to create a picking batch (%s)", self.env.user.login
+        )
+        hasher = hashlib.sha1(str(self._advisory_lock_name).encode())
+        # pg_lock accepts an int8 so we build an hash composed with
+        # contextual information and we throw away some bits
+        int_lock = struct.unpack("q", hasher.digest()[:8])
+
+        self.env.cr.execute("SELECT pg_advisory_xact_lock(%s);", (int_lock,))
+        self.env.cr.fetchone()[0]
+        # Note: if the lock had to wait, the snapshot of the transaction is
+        # very much probably outdated already (i.e. if the transaction which
+        # had the lock before this one set a 'batch_id' on stock.picking this
+        # transaction will not be aware of), we'll probably have a retry. But
+        # the lock can help limit the number of retries.
+        _logger.info(
+            "lock acquired to create a picking batch (%s)", self.env.user.login
+        )
+
+    def _search_pickings_domain(self, picking_types, user=None):
+        domain = [
+            ("picking_type_id", "in", picking_types.ids),
+            ("state", "in", ("assigned", "partially_available")),
+            ("batch_id", "=", False),
+            ("user_id", "=", user.id if user else False),
+        ]
+        return domain
+
+    def _search_pickings(self, picking_types, user=None):
+        # We can't use a limit in the SQL search because the 'priority' fields
+        # is sometimes empty (it seems the inverse StockPicking.priority field
+        # mess up with default on stock.move), we have to sort in Python.
+        return self.env["stock.picking"].search(
+            self._search_pickings_domain(picking_types, user=user)
+        )
+
+    def _sort(self, pickings):
+        return pickings.sorted(
+            lambda picking: (
+                -(int(picking.priority) if picking.priority else 1),
+                picking.scheduled_date,
+                picking.id,
+            )
+        )
+
+    def _precision_weight(self):
+        return self.env["decimal.precision"].precision_get("Product Unit of Measure")
+
+    def _precision_volume(self):
+        return max(
+            6,
+            self.env["decimal.precision"].precision_get("Product Unit of Measure") * 2,
+        )
+
+    def _apply_limits(self, pickings, max_pickings, max_weight, max_volume):
+        current_priority = fields.first(pickings).priority or "1"
+        selected_pickings = self.env["stock.picking"].browse()
+
+        precision_weight = self._precision_weight()
+        precision_volume = self._precision_volume()
+
+        def gt(value1, value2, digits):
+            """Return True if value1 is greater than value2"""
+            return tools.float_compare(value1, value2, precision_digits=digits) == 1
+
+        total_weight = 0.0
+        total_volume = 0.0
+        for picking in pickings:
+            if (picking.priority or "1") != current_priority:
+                # as we sort by priority, exit as soon as the priority changes,
+                # we do not mix priorities to make delivery of high priority
+                # transfers faster
+                break
+
+            weight = self._picking_weight(picking)
+            volume = self._picking_volume(picking)
+            if max_weight and gt(total_weight + weight, max_weight, precision_weight):
+                continue
+
+            if max_volume and gt(total_volume + volume, max_volume, precision_volume):
+                continue
+
+            selected_pickings |= picking
+            total_weight += weight
+            total_volume += volume
+
+            if max_pickings and len(selected_pickings) == max_pickings:
+                # selected enough!
+                break
+
+        return selected_pickings
+
+    def _picking_weight(self, picking):
+        weight = 0.0
+        for line in picking.move_lines:
+            weight += line.product_id.get_total_weight_from_packaging(
+                line.product_uom_qty
+            )
+        return weight
+
+    def _picking_volume(self, picking):
+        volume = 0.0
+        for line in picking.move_lines:
+            product = line.product_id
+            packagings_with_volume = product.with_context(
+                _packaging_filter=lambda p: p.volume
+            ).product_qty_by_packaging(line.product_uom_qty)
+            for packaging_info in packagings_with_volume:
+                if packaging_info.get("is_unit"):
+                    pack_volume = product.volume
+                else:
+                    packaging = self.env["product.packaging"].browse(
+                        packaging_info["id"]
+                    )
+                    pack_volume = packaging.volume
+
+                volume += pack_volume * packaging_info["qty"]
+        return volume
+
+    def _create_batch(self, pickings):
+        return self.env["stock.picking.batch"].create(
+            self._create_batch_values(pickings)
+        )
+
+    def _create_batch_values(self, pickings):
+        return {"picking_ids": [(6, 0, pickings.ids)]}

--- a/shopfloor_batch_automatic_creation/models/__init__.py
+++ b/shopfloor_batch_automatic_creation/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopfloor_menu

--- a/shopfloor_batch_automatic_creation/models/shopfloor_menu.py
+++ b/shopfloor_batch_automatic_creation/models/shopfloor_menu.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ShopfloorMenu(models.Model):
+    _inherit = "shopfloor.menu"
+
+    batch_create = fields.Boolean(
+        string="Automatic Batch Creation",
+        default=False,
+        help='Automatically create a batch when an operator uses the "Get Work"'
+        " button and no existing batch has been found. The system will first look"
+        " for priority transfers and fill up the batch till the defined"
+        " constraints (max of transfers, volume, weight, ...)."
+        " It never mixes priorities, so if you get 2 available priority transfers"
+        " and a max quantity of 3, the batch will only contain the 2"
+        " priority transfers.",
+    )
+    batch_create_max_picking = fields.Integer(
+        string="Max transfers",
+        default=0,
+        help="Maximum number of transfers to add in an automatic batch."
+        " 0 means no limit.",
+    )
+    batch_create_max_volume = fields.Float(
+        string="Max volume (m³)",
+        default=0,
+        digits=(8, 4),
+        help="Maximum volume in cubic meters of goods in transfers to"
+        " add in an automatic batch. 0 means no limit.",
+    )
+    batch_create_max_weight = fields.Float(
+        string="Max Weight (kg)",
+        default=0,
+        help="Maximum weight in kg of goods in transfers to add"
+        " in an automatic batch. 0 means no limit.",
+    )

--- a/shopfloor_batch_automatic_creation/readme/CONTRIBUTORS.rst
+++ b/shopfloor_batch_automatic_creation/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/shopfloor_batch_automatic_creation/readme/DESCRIPTION.rst
+++ b/shopfloor_batch_automatic_creation/readme/DESCRIPTION.rst
@@ -1,0 +1,22 @@
+Extension for Shopfloor's cluster picking.
+
+When a user uses the "Get Work" button on the barcode device, if no transfer
+batch is available, it automatically creates a new batch for the user.
+
+Some options can be configured on the Shopfloor menu:
+
+* Activate or not the batch creation
+* Max number of transfer per batch
+* Max weight per batch
+* Max volume per batch
+
+The rules are:
+
+* Transfers of higher priority are put first in the batch
+* If some transfers are assigned to the user, the batch will only contain
+  those, otherwise, it looks for unassigned transfers
+* Priorities are not mixed to make transfers with higher priority faster
+  e.g. if the limit is 5, with 3 Very Urgent transfer and 10 Normal transfer,
+  the batch will contain only the 3 Very Urgent despite the higher limit
+* The weight and volume are based on the Product Packaging when their weight and
+  volume are defined

--- a/shopfloor_batch_automatic_creation/services/__init__.py
+++ b/shopfloor_batch_automatic_creation/services/__init__.py
@@ -1,0 +1,1 @@
+from . import cluster_picking

--- a/shopfloor_batch_automatic_creation/services/cluster_picking.py
+++ b/shopfloor_batch_automatic_creation/services/cluster_picking.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.component.core import Component
+
+
+class ClusterPicking(Component):
+    _inherit = "shopfloor.cluster.picking"
+
+    def _select_a_picking_batch(self, batches):
+        batch = super()._select_a_picking_batch(batches)
+        if not batch and self.work.menu.batch_create:
+            batch = self._batch_auto_create()
+            batch.write({"user_id": self.env.uid, "state": "in_progress"})
+        return batch
+
+    def _batch_auto_create(self):
+        auto_batch = self.actions_for("picking.batch.auto.create")
+        menu = self.work.menu
+        return auto_batch.create_batch(
+            self.picking_types,
+            max_pickings=menu.batch_create_max_picking,
+            max_volume=menu.batch_create_max_volume,
+            max_weight=menu.batch_create_max_weight,
+        )

--- a/shopfloor_batch_automatic_creation/tests/__init__.py
+++ b/shopfloor_batch_automatic_creation/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_batch_create

--- a/shopfloor_batch_automatic_creation/tests/test_batch_create.py
+++ b/shopfloor_batch_automatic_creation/tests/test_batch_create.py
@@ -1,0 +1,150 @@
+from odoo.addons.shopfloor.tests.common import CommonCase
+
+
+class TestBatchCreate(CommonCase):
+    @classmethod
+    def setUpClassVars(cls, *args, **kwargs):
+        super().setUpClassVars(*args, **kwargs)
+        cls.menu = cls.env.ref("shopfloor.shopfloor_menu_cluster_picking")
+        cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
+        cls.wh = cls.profile.warehouse_id
+        cls.picking_type = cls.menu.picking_type_ids
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData()
+        cls.picking1 = cls._create_picking(
+            lines=[(cls.product_a, 10), (cls.product_b, 10)]
+        )
+        cls.picking2 = cls._create_picking(
+            lines=[(cls.product_c, 10), (cls.product_d, 10)]
+        )
+        cls.picking3 = cls._create_picking(
+            lines=[(cls.product_a, 10), (cls.product_b, 10)]
+        )
+        cls.picking4 = cls._create_picking(
+            lines=[(cls.product_a, 10), (cls.product_b, 10)]
+        )
+        cls.pickings = cls.picking1 + cls.picking2 + cls.picking3 + cls.picking4
+        cls._fill_stock_for_moves(cls.pickings.move_lines)
+        cls.pickings.action_assign()
+
+    def setUp(self):
+        super().setUp()
+        with self.work_on_services(menu=self.menu, profile=self.profile) as work:
+            self.service = work.component(usage="cluster_picking")
+        with self.work_on_actions() as work:
+            self.auto_batch = work.component(usage="picking.batch.auto.create")
+
+    def test_create_batch(self):
+        batch = self.auto_batch.create_batch(self.picking_type)
+        self.assertEqual(batch.picking_ids, self.pickings)
+
+    def test_create_batch_max_pickings(self):
+        batch = self.auto_batch.create_batch(self.picking_type, max_pickings=3)
+        self.assertEqual(
+            batch.picking_ids, self.picking1 + self.picking2 + self.picking3
+        )
+
+    def test_create_batch_priority(self):
+        self.picking2.priority = "3"
+        self.picking3.priority = "3"
+        batch = self.auto_batch.create_batch(self.picking_type, max_pickings=3)
+        # even if we don't reach the max picking, we should not mix the priorities
+        # to make delivery of higher priorities faster
+        self.assertEqual(batch.picking_ids, self.picking2 + self.picking3)
+
+    def test_create_batch_user(self):
+        (self.picking1 + self.picking4).user_id = False
+        (self.picking2 + self.picking3).user_id = self.env.user
+        batch = self.auto_batch.create_batch(self.picking_type, max_pickings=3)
+        # when we have users on pickings, we select only those for the batch
+        self.assertEqual(batch.picking_ids, self.picking2 + self.picking3)
+
+    def test_create_batch_max_weight(self):
+        # each picking has 2 lines of 10 units, set weight of 1kg per unit,
+        # we'll have a total weight of 20kg per picking
+        self.product_a.weight = 1
+        self.product_b.weight = 1
+        # but on the second picking, we set a weight of 2kg per unit: 40 kg per
+        # picking
+        self.product_c.weight = 2
+        self.product_d.weight = 2
+
+        # with a max weight of 20, we can take the first picking, but the
+        # second one would exceed the max, the third can be added because it's
+        # still in the limit
+        batch = self.auto_batch.create_batch(self.picking_type, max_weight=40)
+        self.assertEqual(batch.picking_ids, self.picking1 + self.picking3)
+
+    def test_create_batch_max_volume(self):
+        # each picking has 2 lines of 10 units, set volume of 0.1m3 per unit,
+        # we'll have a total volume of 2m3 per picking
+        self.product_a.volume = 0.1
+        self.product_b.volume = 0.1
+        # but on the second picking, we set a volume of 0.2m3 per unit: 4m3 kg
+        # per picking
+        self.product_c.volume = 0.2
+        self.product_d.volume = 0.2
+
+        # with a max volume of 4, we can take the first picking, but the
+        # second one would exceed the max, the third can be added because it's
+        # still in the limit
+        batch = self.auto_batch.create_batch(self.picking_type, max_volume=4)
+        self.assertEqual(batch.picking_ids, self.picking1 + self.picking3)
+
+    def test_volume(self):
+        # varying volumes because of the packing
+        volume_1 = 0.1
+        volume_2 = 0.25
+        volume_4 = 0.6
+        self.product_a.volume = 0.1
+        self.env["product.packaging"].sudo().create(
+            {
+                "name": "pair",
+                "product_id": self.product_a.id,
+                "qty": 2,
+                "height": 1000,
+                "width": 1000,
+                "lngth": volume_2 * 1000,
+            }
+        )
+        self.env["product.packaging"].sudo().create(
+            {
+                "name": "double pairs",
+                "product_id": self.product_a.id,
+                "qty": 4,
+                "height": 1000,
+                "width": 1000,
+                "lngth": volume_4 * 1000,
+            }
+        )
+        # fmt: off
+        quantity = (
+            1  # unit,
+            + 1 * 2  # 1 * pair
+            + 5 * 4  # 5 * double pairs
+        )
+        expected_volume = (
+            1 * volume_1
+            + 1 * volume_2
+            + 5 * volume_4
+        )
+        # fmt: on
+        picking = self._create_picking(lines=[(self.product_a, quantity)])
+        volume = self.auto_batch._picking_volume(picking)
+        self.assertEqual(volume, expected_volume)
+
+    def test_cluster_picking_select(self):
+        self.menu.sudo().batch_create = True
+        self.menu.sudo().batch_create_max_pickings = 2
+
+        response = self.service.dispatch("find_batch")
+        batch = self.picking1.batch_id
+        self.assertEqual(batch.user_id, self.env.user)
+        self.assertEqual(batch.state, "in_progress")
+
+        data = self.data.picking_batch(batch, with_pickings=True)
+        self.assert_response(
+            response, next_state="confirm_start", data=data,
+        )

--- a/shopfloor_batch_automatic_creation/views/shopfloor_menu_views.xml
+++ b/shopfloor_batch_automatic_creation/views/shopfloor_menu_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="shopfloor_menu_tree_view" model="ir.ui.view">
+        <field name="name">shopfloor menu tree</field>
+        <field name="model">shopfloor.menu</field>
+        <field name="inherit_id" ref="shopfloor.shopfloor_menu_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="editable" />
+            </xpath>
+        </field>
+    </record>
+    <record id="shopfloor_menu_form_view" model="ir.ui.view">
+        <field name="name">shopfloor menu form</field>
+        <field name="model">shopfloor.menu</field>
+        <field name="inherit_id" ref="shopfloor.shopfloor_menu_form_view" />
+        <field name="arch" type="xml">
+            <group name="options" position="inside">
+                <group
+                    name="batch_create"
+                    attrs="{'invisible': [('scenario', '!=', 'cluster_picking')]}"
+                >
+                    <field name="batch_create" />
+                    <field
+                        name="batch_create_max_picking"
+                        attrs="{'invisible': [('batch_create', '=', False)]}"
+                    />
+                    <field
+                        name="batch_create_max_volume"
+                        attrs="{'invisible': [('batch_create', '=', False)]}"
+                    />
+                    <field
+                        name="batch_create_max_weight"
+                        attrs="{'invisible': [('batch_create', '=', False)]}"
+                    />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,6 @@
-odoo13-addon-stock_quant_package_product_packaging @ git+https://github.com/OCA/stock-logistics-workflow@refs/pull/607/head#subdirectory=setup/stock_quant_package_product_packaging
-odoo13-addon-stock_quant_package_dimension @ git+https://github.com/OCA/stock-logistics-workflow@refs/pull/608/head#subdirectory=setup/stock_quant_package_dimension
-odoo13-addon-stock_move_common_dest @ git+https://github.com/OCA/stock-logistics-warehouse@refs/pull/808/head#subdirectory=setup/stock_move_common_dest
-odoo13-addon-stock_picking_completion_info @ git+https://github.com/OCA/stock-logistics-warehouse@refs/pull/808/head#subdirectory=setup/stock_picking_completion_info
 odoo13-addon-stock_location_children @ git+https://github.com/OCA/stock-logistics-warehouse@refs/pull/855/head#subdirectory=setup/stock_location_children
 odoo13-addon-stock_checkout_sync @ git+https://github.com/OCA/stock-logistics-warehouse@refs/pull/907/head#subdirectory=setup/stock_checkout_sync
-odoo13-addon-stock_storage_type @ git+https://github.com/OCA/wms@refs/pull/12/head#subdirectory=setup/stock_storage_type
-odoo13-addon-base_jsonify @ git+https://github.com/OCA/server-tools@refs/pull/1829/head#subdirectory=setup/base_jsonify
+odoo13-addon-stock_packaging_calculator @ git+https://github.com/OCA/stock-logistics-warehouse@refs/pull/939/head#subdirectory=setup/stock_packaging_calculator
+odoo13-addon-product_total_weight_from_packaging @ git+https://github.com/OCA/product-attribute@refs/pull/651/head#subdirectory=setup/product_total_weight_from_packaging
 
 freezegun


### PR DESCRIPTION
When a user uses the "Get Work" button on the barcode device, if no transfer
batch is available, it automatically creates a new batch for the user.

Some options can be configured on the Shopfloor menu:

* Activate or not the batch creation
* Max number of transfer per batch
* Max weight per batch
* Max volume per batch

The rules are:

* Transfers of higher priority are put first in the batch
* If some transfers are assigned to the user, the batch will only contain
  those, otherwise, it looks for unassigned transfers
* Priorities are not mixed to make transfers with higher priority faster
  e.g. if the limit is 5, with 3 Very Urgent transfer and 10 Normal transfer,
  the batch will contain only the 3 Very Urgent despite the higher limit
* The weight and volume are based on the Product Packaging when their weight and
  volume are defined
