### PR TITLE
cluster picking: sort moves by priority

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -322,6 +322,7 @@ class ClusterPicking(Component):
             line.shopfloor_postponed,
             line.location_id.shopfloor_picking_sequence,
             line.location_id.name,
+            -int(line.move_id.priority or 1),
             line.move_id.sequence,
             line.move_id.id,
             line.id,


### PR DESCRIPTION
Priorities goes from "1" (Normal) to "3" (Very Urgent).
We want to pick very urgent first. The priority field may be empty,
ensure they have a normal priority if it happens.