### PR TITLE
Misc fixes for zone picking

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1,7 +1,7 @@
 import functools
 
 from odoo.fields import first
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 from odoo.addons.base_rest.components.service import to_bool, to_int
 from odoo.addons.component.core import Component
@@ -461,13 +461,15 @@ class ZonePicking(Component, ChangePackLotMixin):
     def _set_destination_location(
         self, zone_location, picking_type, move_line, quantity, confirmation, location
     ):
+        location_changed = False
+        response = None
         # Ask confirmation to the user if the scanned location is not in the
         # expected ones but is valid (in picking type's default destination)
         if not location.is_sublocation_of(move_line.location_dest_id) and (
             not confirmation
             and location.is_sublocation_of(picking_type.default_location_dest_id)
         ):
-            return self._response_for_set_line_destination(
+            response = self._response_for_set_line_destination(
                 zone_location,
                 picking_type,
                 move_line,
@@ -476,6 +478,7 @@ class ZonePicking(Component, ChangePackLotMixin):
                 ),
                 confirmation_required=True,
             )
+            return (location_changed, response)
         # A valid location is a sub-location of the original destination, or a
         # sub-location of the picking type's default destination location if
         # `confirmation is True
@@ -483,20 +486,22 @@ class ZonePicking(Component, ChangePackLotMixin):
             confirmation
             and not location.is_sublocation_of(picking_type.default_location_dest_id)
         ):
-            return self._response_for_set_line_destination(
+            response = self._response_for_set_line_destination(
                 zone_location,
                 picking_type,
                 move_line,
                 message=self.msg_store.dest_location_not_allowed(),
             )
+            return (location_changed, response)
         # If no destination package
         if not move_line.result_package_id:
-            return self._response_for_set_line_destination(
+            response = self._response_for_set_line_destination(
                 zone_location,
                 picking_type,
                 move_line,
                 message=self.msg_store.dest_package_required(),
             )
+            return (location_changed, response)
         # destination location set to the scanned one
         move_line.location_dest_id = location
         # the quantity done is set to the passed quantity
@@ -508,12 +513,14 @@ class ZonePicking(Component, ChangePackLotMixin):
         # try to re-assign any split move (in case of partial qty)
         if "confirmed" in move_line.picking_id.move_lines.mapped("state"):
             move_line.picking_id.action_assign()
+        location_changed = True
         # Zero check
         zero_check = picking_type.shopfloor_zero_check
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
-            return self._response_for_zero_check(
+            response = self._response_for_zero_check(
                 zone_location, picking_type, move_line.location_id
             )
+        return (location_changed, response)
 
     def _is_package_empty(self, package):
         return not bool(package.quant_ids)
@@ -528,41 +535,55 @@ class ZonePicking(Component, ChangePackLotMixin):
             )
         )
 
+    def _move_line_compare_qty(self, move_line, qty):
+        rounding = move_line.product_uom_id.rounding
+        return float_compare(
+            qty, move_line.product_uom_qty, precision_rounding=rounding
+        )
+
+    def _move_line_full_qty(self, move_line, qty):
+        rounding = move_line.product_uom_id.rounding
+        return float_is_zero(
+            move_line.product_uom_qty - qty, precision_rounding=rounding
+        )
+
     def _set_destination_package(
         self, zone_location, picking_type, move_line, quantity, package
     ):
+        package_changed = False
+        response = None
         # A valid package is:
         # * an empty package
         # * not used as destination for another move line
         if not self._is_package_empty(package):
-            return self._response_for_set_line_destination(
+            response = self._response_for_set_line_destination(
                 zone_location,
                 picking_type,
                 move_line,
                 message=self.msg_store.package_not_empty(package),
             )
+            return (package_changed, response)
         if self._is_package_already_used(package):
-            return self._response_for_set_line_destination(
+            response = self._response_for_set_line_destination(
                 zone_location,
                 picking_type,
                 move_line,
                 message=self.msg_store.package_already_used(package),
             )
+            return (package_changed, response)
         # the quantity done is set to the passed quantity
         # but if we move a partial qty, we need to split the move line
-        rounding = move_line.product_uom_id.rounding
-        compare = float_compare(
-            quantity, move_line.product_uom_qty, precision_rounding=rounding
-        )
+        compare = self._move_line_compare_qty(move_line, quantity)
         qty_lesser = compare == -1
         qty_greater = compare == 1
         if qty_greater:
-            return self._response_for_set_line_destination(
+            response = self._response_for_set_line_destination(
                 zone_location,
                 picking_type,
                 move_line,
                 message=self.msg_store.unable_to_pick_more(move_line.product_uom_qty),
             )
+            return (package_changed, response)
         elif qty_lesser:
             # split the move line which will be processed later
             remaining = move_line.product_uom_qty - quantity
@@ -578,12 +599,14 @@ class ZonePicking(Component, ChangePackLotMixin):
         move_line.result_package_id = package
         # the field ``shopfloor_user_id`` is updated with the current user
         move_line.shopfloor_user_id = self.env.user
+        package_changed = True
         # Zero check
         zero_check = picking_type.shopfloor_zero_check
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
-            return self._response_for_zero_check(
+            response = self._response_for_zero_check(
                 zone_location, picking_type, move_line.location_id
             )
+        return (package_changed, response)
 
     def set_destination(
         self,
@@ -647,29 +670,50 @@ class ZonePicking(Component, ChangePackLotMixin):
         move_line = self.env["stock.move.line"].browse(move_line_id)
         if not move_line.exists():
             return self._response_for_start(message=self.msg_store.record_not_found())
+
+        pkg_moved = False
         search = self.actions_for("search")
-        # When the barcode is a location
-        location = search.location_from_scan(barcode)
-        if location:
-            response = self._set_destination_location(
-                zone_location, picking_type, move_line, quantity, confirmation, location
-            )
-            if response:
-                return response
+        accept_only_package = not self._move_line_full_qty(move_line, quantity)
+
+        if not accept_only_package:
+            # When the barcode is a location
+            location = search.location_from_scan(barcode)
+            if location:
+                pkg_moved, response = self._set_destination_location(
+                    zone_location,
+                    picking_type,
+                    move_line,
+                    quantity,
+                    confirmation,
+                    location,
+                )
+                if response:
+                    return response
+
         # When the barcode is a package
         package = search.package_from_scan(barcode)
         if package:
             location = move_line.location_dest_id
-            response = self._set_destination_package(
+            pkg_moved, response = self._set_destination_package(
                 zone_location, picking_type, move_line, quantity, package
             )
             if response:
                 return response
+
+        message = None
+
+        if not pkg_moved and not package and accept_only_package:
+            message = self.msg_store.package_not_found_for_barcode(barcode)
+            return self._response_for_set_line_destination(
+                zone_location, picking_type, move_line, message=message
+            )
+
+        if pkg_moved:
+            message = self.msg_store.confirm_pack_moved()
+
         # Process the next line
         response = self.list_move_lines(zone_location.id, picking_type.id)
-        return self._response(
-            base_response=response, message=self.msg_store.confirm_pack_moved(),
-        )
+        return self._response(base_response=response, message=message,)
 
     def is_zero(self, zone_location_id, picking_type_id, move_line_id, zero):
         """Confirm or not if the source location of a move has zero qty
@@ -1148,6 +1192,7 @@ class ZonePicking(Component, ChangePackLotMixin):
                 move_lines,
                 message=self.msg_store.record_not_found(),
             )
+
         buffer_lines = self._find_buffer_move_lines(
             zone_location, picking_type, dest_package=package
         )

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1239,6 +1239,9 @@ class ZonePicking(Component, ChangePackLotMixin):
             return self._response_for_start(
                 message=self.msg_store.picking_type_complete(picking_type)
             )
+        # TODO: when we have no lines here
+        # we should not redirect to `unload_set_destination`
+        # because we'll have nothing to display (currently the UI is broken).
         return self._response_for_unload_set_destination(
             zone_location,
             picking_type,

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -254,7 +254,7 @@ export var ClusterPicking = Vue.component("cluster-picking", {
                         ).quantity;
                     },
                     on_qty_edit: qty => {
-                        this.scan_destination_qty = parseInt(qty);
+                        this.scan_destination_qty = parseInt(qty, 10);
                     },
                     on_scan: scanned => {
                         this.wait_call(

--- a/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
@@ -194,6 +194,7 @@ export var LocationContentTransfer = Vue.component("location-content-transfer", 
         return {
             usage: "location_content_transfer",
             initial_state_key: "scan_location",
+            scan_destination_qty: 0,
             states: {
                 init: {
                     enter: () => {
@@ -271,7 +272,7 @@ export var LocationContentTransfer = Vue.component("location-content-transfer", 
                         qty_edit: "on_qty_update",
                     },
                     on_qty_update: qty => {
-                        this.state.data.destination_qty = qty;
+                        this.scan_destination_qty = parseInt(qty, 10);
                     },
                     on_scan: scanned => {
                         let endpoint, endpoint_data;
@@ -291,9 +292,7 @@ export var LocationContentTransfer = Vue.component("location-content-transfer", 
                                 location_id: data.move_line.location_src.id,
                                 barcode: scanned.text,
                                 confirmation: data.confirmation_required,
-                                quantity:
-                                    this.state.data.destination_qty ||
-                                    data.move_line.quantity,
+                                quantity: this.scan_destination_qty,
                             };
                         }
                         this.wait_call(this.odoo.call(endpoint, endpoint_data));

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -376,6 +376,7 @@ export var ZonePicking = Vue.component("zone-picking", {
             usage: "zone_picking",
             initial_state_key: "scan_location",
             order_lines_by: "priority",
+            scan_destination_qty: 0,
             states: {
                 scan_location: {
                     display_info: {
@@ -433,12 +434,19 @@ export var ZonePicking = Vue.component("zone-picking", {
                     display_info: {
                         title: "Set destination",
                         scan_placeholder: "Scan location or package",
+                        scan_placeholder_full: "Scan location or package",
+                        scan_placeholder_partial: "Scan package",
                     },
                     events: {
                         qty_edit: "on_qty_update",
                     },
                     on_qty_update: qty => {
-                        this.state.data.destination_qty = qty;
+                        this.scan_destination_qty = parseInt(qty, 10);
+                        if (this.state.data.move_line.quantity != qty) {
+                            this.state.display_info.scan_placeholder = this.state.display_info.scan_placeholder_partial;
+                        } else {
+                            this.state.display_info.scan_placeholder = this.state.display_info.scan_placeholder_full;
+                        }
                     },
                     on_scan: scanned => {
                         const data = this.state.data;
@@ -448,8 +456,7 @@ export var ZonePicking = Vue.component("zone-picking", {
                                 picking_type_id: this.current_picking_type().id,
                                 move_line_id: data.move_line.id,
                                 barcode: scanned.text,
-                                quantity:
-                                    data.destination_qty || data.move_line.quantity,
+                                quantity: this.scan_destination_qty,
                                 confirmation: data.confirmation_required,
                             })
                         );

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -133,6 +133,7 @@ const template_mobile = `
                 :message="{body: 'Full order picking, no more operation.'}"
                 />
             <picking-summary
+                v-if="state.data.move_line"
                 :record="state.data.move_line.picking"
                 :records="[state.data.move_line]"
                 :records_grouped="picking_summary_records_grouped([state.data.move_line])"
@@ -140,12 +141,19 @@ const template_mobile = `
                 :key="make_state_component_key(['picking-summary'])"
                 />
             <item-detail-card
+                v-if="state.data.move_line"
                 :key="make_state_component_key(['detail-move-line-dest-pack', state.data.move_line.id])"
                 :record="state.data.move_line"
                 :options="{main: true, key_title: 'package_dest.name'}"
                 :card_color="utils.colors.color_for('screen_step_todo')"
                 class="mt-2"
                 />
+            <div class="no-line-found" v-if="state.data.move_line">
+                <!-- In theory this should not happen.
+                Handled only because something seems wrong backend side
+                and we might get here w/ no line info. -->
+                No line to process.
+            </div>
         </div>
 
         <stock-zero-check


### PR DESCRIPTION
1. fix issue w/ pkg qty widget w/out unique key for pkgs
2. change validation for partial picking: a package is now required
* front: change the scan widget message
* back: send back to same screen and show "package not found" message
3. fix issue w/ qty handling on set line destination reload (qty was lost due to pt 2)
 
