### PR TITLE
location transfer: ensure to process pickings sharing the same source location

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -447,3 +447,9 @@ class MessageAction(Component):
             "message_type": "error",
             "body": _("Lines have different destination location."),
         }
+
+    def new_move_lines_not_assigned(self):
+        return {
+            "message_type": "error",
+            "body": _("New move lines cannot be assigned: canceled."),
+        }

--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -4,12 +4,18 @@ from odoo import models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    def split_other_move_lines(self, move_lines):
+    def split_other_move_lines(self, move_lines, intersection=False):
         """Substract `move_lines` from `move.move_line_ids`, put the result
         in a new move and returns it.
+
+        If `intersection` is set to `True`, this is the common lines between
+        `move_lines` and `move.move_line_ids` which will be put in a new move.
         """
         self.ensure_one()
-        other_move_lines = self.move_line_ids - move_lines
+        if intersection:
+            other_move_lines = self.move_line_ids & move_lines
+        else:
+            other_move_lines = self.move_line_ids - move_lines
         if other_move_lines:
             qty_to_split = sum(other_move_lines.mapped("product_uom_qty"))
             backorder_move_id = self._split(qty_to_split)

--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class StockMoveLine(models.Model):
@@ -21,3 +22,88 @@ class StockMoveLine(models.Model):
 
     # allow domain on picking_id.xxx without too much perf penalty
     picking_id = fields.Many2one(auto_join=True)
+
+    def _split_pickings_from_source_location(self):
+        """Ensure that the related pickings will have the same source location.
+
+        Some pickings related could have other unrelated move lines, as such we
+        have to split them to contain only the move lines related to the expected
+        source location.
+
+        Example:
+
+            Initial data:
+
+                PICK1:
+                    - move line with source location LOC1
+                    - move line with source location LOC2
+                PICK2:
+                    - move line with source location LOC2
+                    - move line with source location LOC3
+
+            Then we process move lines related to LOC2 with this method, we get:
+
+                PICK1:
+                    - move line with source location LOC1
+                PICK2:
+                    - move line with source location LOC3
+                PICK3:
+                    - move line with source location LOC2
+                    - move line with source location LOC2
+
+        Return the new picking (in case a split has been made), or the current
+        related pickings.
+        """
+        location_src_to_process = self.location_id
+        if location_src_to_process and len(location_src_to_process) != 1:
+            raise UserError(
+                _("Move lines processed have to share the same source location.")
+            )
+        pickings = self.picking_id
+        move_lines_to_process_ids = []
+        for picking in pickings:
+            location_src = picking.mapped("move_line_ids.location_id")
+            if len(location_src) == 1:
+                continue
+            # Get the related move lines among the picking and split them
+            move_lines_to_process_ids.extend(
+                set(picking.move_line_ids.ids) & set(self.ids)
+            )
+        # Put all move lines related to the source location in a separate picking
+        move_lines_to_process = self.browse(move_lines_to_process_ids)
+        new_move_ids = []
+        for move_line in move_lines_to_process:
+            new_move = move_line.move_id.split_other_move_lines(
+                move_line, intersection=True
+            )
+            new_move._recompute_state()
+            new_move_ids.append(new_move.id)
+        # If we have new moves, create the backorder picking
+        # NOTE: code copy/pasted & adapted from OCA module 'stock_split_picking'
+        new_moves = self.env["stock.move"].browse(new_move_ids)
+        if new_moves:
+            picking = pickings[0]
+            new_picking = picking.copy(
+                {
+                    "name": "/",
+                    "move_lines": [],
+                    "move_line_ids": [],
+                    "backorder_id": picking.id,
+                }
+            )
+            pickings.message_post(
+                body=_(
+                    'The backorder <a href="#" '
+                    'data-oe-model="stock.picking" '
+                    'data-oe-id="%d">%s</a> has been created.'
+                )
+                % (new_picking.id, new_picking.name)
+            )
+            new_moves.write({"picking_id": new_picking.id})
+            new_moves.mapped("move_line_ids").write({"picking_id": new_picking.id})
+            new_moves.move_line_ids.package_level_id.write(
+                {"picking_id": new_picking.id}
+            )
+            new_moves._action_assign()
+            pickings = new_picking
+        return pickings

--- a/shopfloor/tests/common.py
+++ b/shopfloor/tests/common.py
@@ -52,9 +52,9 @@ class CommonCase(SavepointCase, ComponentMixin):
     maxDiff = None
 
     @contextmanager
-    def work_on_services(self, **params):
+    def work_on_services(self, env=None, **params):
         params = params or {}
-        collection = _PseudoCollection("shopfloor.service", self.env)
+        collection = _PseudoCollection("shopfloor.service", env or self.env)
         yield WorkContext(
             model_name="rest.service.registration", collection=collection, **params
         )

--- a/shopfloor/tests/test_location_content_transfer_base.py
+++ b/shopfloor/tests/test_location_content_transfer_base.py
@@ -57,7 +57,7 @@ class LocationContentTransferCommonCase(CommonCase):
         # data methods have their own tests
         lines = pickings.move_line_ids.filtered(lambda line: not line.package_level_id)
         package_levels = pickings.package_level_ids
-        location = lines.mapped("location_id")
+        location = pickings.mapped("move_line_ids.location_id")
         self.assert_response(
             response,
             next_state=state,

--- a/shopfloor/tests/test_stock_split.py
+++ b/shopfloor/tests/test_stock_split.py
@@ -1,0 +1,128 @@
+from odoo.tests import tagged
+from odoo.tests.common import SavepointCase
+
+
+@tagged("post_install", "-at_install")
+class TestStockSplit(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestStockSplit, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.delivery_steps = "pick_pack_ship"
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.pack_location = cls.warehouse.wh_pack_stock_loc_id
+        cls.ship_location = cls.warehouse.wh_output_stock_loc_id
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        # Create a product
+        cls.product_a = (
+            cls.env["product.product"]
+            .sudo()
+            .create(
+                {
+                    "name": "Product A",
+                    "type": "product",
+                    "default_code": "A",
+                    "barcode": "A",
+                    "weight": 2,
+                }
+            )
+        )
+        cls.product_a_packaging = (
+            cls.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "Box",
+                    "product_id": cls.product_a.id,
+                    "barcode": "ProductABox",
+                }
+            )
+        )
+        # Put product_a quantities in different packages to get several move lines
+        cls.package_1 = cls.env["stock.quant.package"].create({"name": "PACKAGE_1"})
+        cls.package_2 = cls.env["stock.quant.package"].create({"name": "PACKAGE_2"})
+        cls.package_3 = cls.env["stock.quant.package"].create({"name": "PACKAGE_3"})
+        cls.package_4 = cls.env["stock.quant.package"].create({"name": "PACKAGE_4"})
+        cls._update_qty_in_location(
+            cls.stock_location, cls.product_a, 6, package=cls.package_1
+        )
+        cls._update_qty_in_location(
+            cls.stock_location, cls.product_a, 4, package=cls.package_2
+        )
+        cls._update_qty_in_location(
+            cls.stock_location, cls.product_a, 5, package=cls.package_3
+        )
+        # Create the pick/pack/ship transfer
+        cls.ship_move_a = cls.env["stock.move"].create(
+            {
+                "name": cls.product_a.display_name,
+                "product_id": cls.product_a.id,
+                "product_uom_qty": 15.0,
+                "product_uom": cls.product_a.uom_id.id,
+                "location_id": cls.ship_location.id,
+                "location_dest_id": cls.customer_location.id,
+                "warehouse_id": cls.warehouse.id,
+                "picking_type_id": cls.warehouse.out_type_id.id,
+                "procure_method": "make_to_order",
+                "state": "draft",
+            }
+        )
+        cls.ship_move_a._assign_picking()
+        cls.ship_move_a._action_confirm(merge=False)
+        cls.pack_move = cls.ship_move_a.move_orig_ids[0]
+        cls.pick_move = cls.pack_move.move_orig_ids[0]
+        cls.picking = cls.pick_move.picking_id
+        cls.packing = cls.pack_move.picking_id
+        cls.picking.action_assign()
+
+    @classmethod
+    def _update_qty_in_location(
+        cls, location, product, quantity, package=None, lot=None
+    ):
+        quants = cls.env["stock.quant"]._gather(
+            product, location, lot_id=lot, package_id=package, strict=True
+        )
+        # this method adds the quantity to the current quantity, so remove it
+        quantity -= sum(quants.mapped("quantity"))
+        cls.env["stock.quant"]._update_available_quantity(
+            product, location, quantity, package_id=package, lot_id=lot
+        )
+
+    def test_split_pickings_from_source_location(self):
+        dest_location = self.pick_move.location_dest_id.sudo().copy(
+            {
+                "name": self.pick_move.location_dest_id.name + "_2",
+                "barcode": self.pick_move.location_dest_id.barcode + "_2",
+                "location_id": self.pick_move.location_dest_id.id,
+            }
+        )
+        # Pick goods from stock and move some of them to a different destination
+        self.assertEqual(self.pick_move.state, "assigned")
+        for i, move_line in enumerate(self.pick_move.move_line_ids):
+            move_line.qty_done = move_line.product_uom_qty
+            if i % 2:
+                move_line.location_dest_id = dest_location
+        self.pick_move.with_context(_sf_no_backorder=True)._action_done()
+        self.assertEqual(self.pick_move.state, "done")
+        # Pack step, we want to split move lines from common source location
+        self.assertEqual(self.pack_move.state, "assigned")
+        move_lines_to_process = self.pack_move.move_line_ids.filtered(
+            lambda ml: ml.location_id == dest_location
+        )
+        self.assertEqual(len(self.pack_move.move_line_ids), 3)
+        self.assertEqual(len(self.packing.package_level_ids), 3)
+        self.assertEqual(len(move_lines_to_process), 1)
+        new_packing = move_lines_to_process._split_pickings_from_source_location()
+        self.assertEqual(len(self.packing.package_level_ids), 2)
+        self.assertEqual(len(new_packing.package_level_ids), 1)
+        self.assertEqual(len(new_packing.move_line_ids), 1)
+        self.assertTrue(new_packing != self.packing)
+        self.assertEqual(new_packing.backorder_id, self.packing)
+        self.assertEqual(
+            self.pick_move.move_dest_ids.picking_id, self.packing | new_packing
+        )
+        self.assertEqual(move_lines_to_process.state, "assigned")
+        self.assertEqual(
+            set(self.pack_move.move_line_ids.mapped("state")), {"assigned"}
+        )


### PR DESCRIPTION
And test a complete flow:

    1) Operator-1 processes the first pallet with the "zone picking" scenario
       to move the goods to PACK-1:

        move1 PICK -> PACK-1 'done'

    2) Operator-1 processes the second pallet with the "zone picking" scenario
       to move the goods to PACK-2:

        move1 PICK -> PACK-2 'done'

    3) Operator-2 with the "location content transfer" scenario scan
      the location where the first pallet is (PACK-1):
        - the app should found one move line
        - this move line will be put in its own transfer as its sibling lines
          are in another source location
        - as such the app should ask the destination location (as there is
          only one line)

        move1 PACK-2 -> SHIP (still handled by the operator so not 'done')

    4) Operator-3 with the "location content transfer" scenario scan
      the location where the first pallet is (PACK-1):
        - nothing is found as the pallet is currently handled by Operator-2

    5) If Operator-2 is unable to finish the flow with the first pallet
      (barcode device out of battery... etc), he should be able to recover
      what he started.

    6) Operator-2 then finishes its operation regarding the first pallet, and
      scan the location where the second pallet is (PACK-2). He should find
      only this pallet available.

Issue 1373