### PR TITLE
Shopfloor misc fixes

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/detail/detail_package.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_package.js
@@ -39,7 +39,7 @@ Vue.component("detail-package", {
                 <detail-picking
                     v-for="picking in record.pickings"
                     :key="picking.id"
-                    :record="record"
+                    :record="picking"
                     />
             </div>
         </div>

--- a/shopfloor_mobile/static/wms/src/components/userInformation/userInformation.js
+++ b/shopfloor_mobile/static/wms/src/components/userInformation/userInformation.js
@@ -3,12 +3,16 @@ Vue.component("user-information", {
     props: ["message"],
     template: `
     <v-alert :type="alert_type" tile>
-        {{ _.result(message, "body") }}
+        <p v-for="line in message_lines" v-if="line" v-text="line"/>
     </v-alert>
     `,
     computed: {
         alert_type: function() {
             return _.result(this.message, "message_type", "info");
+        },
+        message_lines: function() {
+            const msg = _.result(this.message, "body");
+            return msg ? msg.split("\n") : [];
         },
     },
 });

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -38,7 +38,7 @@ export var Checkout = Vue.component("checkout", {
                 <manual-select
                     :records="state.data.pickings"
                     :options="manual_selection_manual_select_options()"
-                    :key="make_state_component_key(['manual-select'])"
+                    :key="make_state_component_key(['checkout', 'manual-select'])"
                     />
                 <div class="button-list button-vertical-list full">
                     <v-row align="center">

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -273,9 +273,6 @@ export var Checkout = Vue.component("checkout", {
                         title: "Choose an order to pack",
                         scan_placeholder: "Scan pack / picking / location",
                     },
-                    enter: () => {
-                        this.state_reset_data();
-                    },
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("scan_document", {barcode: scanned.text})

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -154,9 +154,6 @@ export var ClusterPicking = Vue.component("cluster-picking", {
             scan_destination_qty: 1,
             states: {
                 start: {
-                    enter: () => {
-                        this.state_reset_data();
-                    },
                     on_get_work: evt => {
                         this.wait_call(this.odoo.call("find_batch"));
                     },

--- a/shopfloor_mobile/static/wms/src/scenario/delivery.js
+++ b/shopfloor_mobile/static/wms/src/scenario/delivery.js
@@ -164,9 +164,6 @@ export var Delivery = Vue.component("checkout", {
                         title: "Start by scanning something",
                         scan_placeholder: "Scan pack / picking",
                     },
-                    enter: () => {
-                        this.state_reset_data();
-                    },
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("scan_deliver", {barcode: scanned.text})

--- a/shopfloor_mobile/static/wms/src/scenario/delivery.js
+++ b/shopfloor_mobile/static/wms/src/scenario/delivery.js
@@ -21,7 +21,7 @@ export var Delivery = Vue.component("checkout", {
                     :records_grouped="deliver_picking_summary_records_grouped(state.data.picking)"
                     :action_cancel_package_key="'package_src'"
                     :list_options="deliver_move_line_list_options(state.data.picking)"
-                    :key="make_state_component_key(['manual-select', 'detail-picking', current_picking().id])"
+                    :key="make_state_component_key(['picking-summary', 'detail-picking', state.data.picking.id])"
                     />
             </div>
             <div v-if="state_is('manual_selection')">
@@ -29,7 +29,7 @@ export var Delivery = Vue.component("checkout", {
                     class="with-progress-bar"
                     :records="state.visible_records(this.state.data.pickings)"
                     :options="manual_select_options()"
-                    :key="make_state_component_key(['manual-select'])"
+                    :key="make_state_component_key(['delivery', 'manual-select'])"
                     />
             </div>
             <div class="button-list button-vertical-list full">

--- a/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
@@ -198,7 +198,6 @@ export var LocationContentTransfer = Vue.component("location-content-transfer", 
             states: {
                 init: {
                     enter: () => {
-                        this.state_reset_data();
                         this.wait_call(this.odoo.call("start_or_recover"));
                     },
                 },

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -317,15 +317,14 @@ export var ScenarioBaseMixin = {
             this.reset_notification();
         },
         set_message: function(message) {
-            this.messages.message = message;
+            this.$set(this.messages, "message", message);
         },
         set_popup: function(popup) {
-            this.messages.popup.body = popup.body;
+            this.$set(this.messages, "popup", popup);
         },
         reset_notification: function() {
-            this.messages.message = null;
-            this.messages.message_type = null;
-            this.messages.popup.body = null;
+            this.$set(this.messages, "message", {body: null, message_type: null});
+            this.$set(this.messages, "popup", {body: null});
         },
         display_app_error: function(error) {
             this.set_message({

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -211,6 +211,7 @@ export var ScenarioBaseMixin = {
                 or any other case where you want to erase all data on demand.
                 */
                 this.state_reset_data_all();
+                this.reset_notification();
                 /**
                  * Special case: if `init` is defined as state
                  * you can use it do particular initialization.
@@ -285,7 +286,7 @@ export var ScenarioBaseMixin = {
             if (result.popup) {
                 this.set_popup(result.popup);
             }
-            if (this.current_state_key != state_key) {
+            if (state_key != this.$route.params.state) {
                 this.state_to(state_key);
             } else {
                 // Refresh computed state anyway

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -16,7 +16,16 @@ export var ScenarioBaseMixin = {
             current_state_key: "",
             states: {},
             usage: "", // Match component usage on odoo,
+            menu_item_id: false,
         };
+    },
+    watch: {
+        "$route.params.menu_id": function() {
+            this.menu_item_id = this._get_menu_item_id();
+        },
+    },
+    created: function() {
+        this.menu_item_id = this._get_menu_item_id();
     },
     beforeRouteUpdate(to, from, next) {
         // Load initial state
@@ -34,20 +43,6 @@ export var ScenarioBaseMixin = {
         this._state_load(this.$route.params.state);
     },
     computed: {
-        menu_item_id: function() {
-            const menu_id = Number.parseInt(this.$route.params.menu_id, 10);
-            if (Number.isNaN(menu_id)) {
-                /*
-                It's very handy for demo data to reference always the same menu id.
-                Since the menu id is included in the URL
-                it allows to reload the page w/out having to refresh menu items.
-                This way you can define multiple scenario w/ different menu items
-                and you can tag them with the same reusable label (eg: case_1).
-                */
-                return this.$route.params.menu_id;
-            }
-            return menu_id;
-        },
         odoo: function() {
             const odoo_params = {
                 process_menu_id: this.menu_item_id,
@@ -103,6 +98,20 @@ export var ScenarioBaseMixin = {
         },
     },
     methods: {
+        _get_menu_item_id: function() {
+            const menu_id = Number.parseInt(this.$route.params.menu_id, 10);
+            if (Number.isNaN(menu_id)) {
+                /*
+                It's very handy for demo data to reference always the same menu id.
+                Since the menu id is included in the URL
+                it allows to reload the page w/out having to refresh menu items.
+                This way you can define multiple scenario w/ different menu items
+                and you can tag them with the same reusable label (eg: case_1).
+                */
+                return this.$route.params.menu_id;
+            }
+            return menu_id;
+        },
         screen_klass: function() {
             return this.usage + " " + "state-" + this.state.key;
         },

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -342,8 +342,13 @@ export var ScenarioBaseMixin = {
             this.$set(this.messages, "popup", {body: null});
         },
         display_app_error: function(error) {
+            let parts = [error.status, error.name];
+            if (error.description) {
+                parts.push("\n" + error.description);
+            }
+            parts.push("\nURL: " + error.response.url);
             this.set_message({
-                body: error.description,
+                body: parts.join(" "),
                 message_type: "error",
             });
         },

--- a/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
@@ -11,9 +11,6 @@ export var SinglePackStatesMixin = {
                         title: "Start by scanning a pack or a location",
                         scan_placeholder: "Scan pack",
                     },
-                    enter: () => {
-                        this.state_reset_data();
-                    },
                     on_scan: scanned => {
                         const data = this.state.data;
                         this.wait_call(


### PR DESCRIPTION
Commits are self-explanatory.

The most important part is: refactor the current state computation.
The old implementation was leading to inconsistent behaviors due to the fact that the `this.state` object was not always recomputed when the state data was updated.

* Fix weird behavior when switching from pack to delivery scenario

  The issue was kind of easy to reproduce, the solution was not.
  Apparently was due to inconsistent transition within states
  and the related computation of state data.
  Current state computation (used everywhere to unify access to state data)
  has been refactored and the transition from one state to another made more solid.

* Fix checkout package line de-selection
  
  De-selection of the line on the `select_package` state was broken
  because the backend was not sending back `picking` every time.

* Fix package detail list of pickings (displaying packages 2 times)
* Fix internal server error display 

  Such errors do not have a description hence the message for the UI was empty.