### PR TITLE
Front handle loading

### DIFF
--- a/shopfloor_mobile/static/wms/index.html
+++ b/shopfloor_mobile/static/wms/index.html
@@ -75,7 +75,8 @@
     <script src="src/scenario/location_content_transfer.js" type="module"></script>
     <script src="src/scenario/zone_picking.js" type="module"></script>
     <script src="src/scenario/scan_anything.js" type="module"></script>
-    <script type="module" src="src/main.js"></script>
+    <script src="src/fetch.js"></script>
+    <script src="src/main.js" type="module"></script>
   </head>
   <body>
     <noscript>

--- a/shopfloor_mobile/static/wms/src/components/misc.js
+++ b/shopfloor_mobile/static/wms/src/components/misc.js
@@ -368,3 +368,23 @@ Vue.component("line-stock-out", {
   </div>
 `,
 });
+
+Vue.component("screen-loading", {
+    props: {
+        loading: {
+            type: Boolean,
+        },
+    },
+    template: `
+    <v-overlay :value="loading" opacity="0.6">
+      <v-row
+          align="center"
+          justify="center">
+          <v-col cols="12" class="text-center">
+              <v-progress-circular indeterminate :color="utils.colors.color_for('spinner')" />
+              <p class="mt-4">Waiting...</p>
+          </v-col>
+      </v-row>
+    </v-overlay>
+  `,
+});

--- a/shopfloor_mobile/static/wms/src/components/screen.js
+++ b/shopfloor_mobile/static/wms/src/components/screen.js
@@ -149,6 +149,7 @@ Vue.component("Screen", {
             </div>
 
             <v-container>
+                <screen-loading :loading="$root.loading" />
                 <div class="main-content">
                     <slot>
                         <span v-if="this.$root.has_profile">No content provided.</span>
@@ -158,10 +159,6 @@ Vue.component("Screen", {
             <!-- TODO: use flexbox to put it always at the bottom -->
             <div class="footer" v-if="$slots.footer">
                 <slot name="footer">Optional footer - no content</slot>
-            </div>
-            <div class="loading" v-if="$root.loading && !$root.demo_mode">
-                Loading...
-                <!-- TODO: show a spinner + FIXME: demo mode should work properly -->
             </div>
         </v-content>
     </v-app>

--- a/shopfloor_mobile/static/wms/src/fetch.js
+++ b/shopfloor_mobile/static/wms/src/fetch.js
@@ -1,0 +1,42 @@
+/* eslint-disable valid-jsdoc */
+/* eslint-disable no-implicit-globals */
+/* eslint-disable strict */
+
+// Credit https://stackoverflow.com/questions/43792026
+
+var _oldFetch = fetch;
+
+/**
+ * Patch `fetch` to trigger events on start and end request.
+ */
+window.fetch = function() {
+    // Create hooks
+    var fetchStart = new Event("fetchStart", {
+        view: document,
+        bubbles: true,
+        cancelable: false,
+    });
+    var fetchEnd = new Event("fetchEnd", {
+        view: document,
+        bubbles: true,
+        cancelable: false,
+    });
+
+    // Pass the supplied arguments to the real fetch function
+    var fetchCall = _oldFetch.apply(this, arguments);
+
+    // Trigger the fetchStart event
+    document.dispatchEvent(fetchStart);
+
+    fetchCall
+        .then(function() {
+            // Trigger the fetchEnd event
+            document.dispatchEvent(fetchEnd);
+        })
+        .catch(function() {
+            // Trigger the fetchEnd event
+            document.dispatchEvent(fetchEnd);
+        });
+
+    return fetchCall;
+};

--- a/shopfloor_mobile/static/wms/src/main.js
+++ b/shopfloor_mobile/static/wms/src/main.js
@@ -45,11 +45,18 @@ const app = new Vue({
         };
     },
     created: function() {
+        const self = this;
         this.demo_mode = window.location.pathname.includes("demo");
         if (this.demo_mode) {
             this._loadDemoResources();
         }
         this.loadConfig();
+        document.addEventListener("fetchStart", function() {
+            self.loading = true;
+        });
+        document.addEventListener("fetchEnd", function() {
+            self.loading = false;
+        });
     },
     mounted: function() {
         const self = this;
@@ -139,14 +146,12 @@ const app = new Vue({
         },
         _loadConfig: function() {
             const self = this;
-            self.loading = true;
             const odoo = self.getOdoo({usage: "app"});
             return odoo.call("user_config").then(function(result) {
                 if (!_.isUndefined(result.data)) {
                     self.appconfig = result.data;
                     self.authenticated = true;
                     self.$storage.set("appconfig", self.appconfig);
-                    self.loading = false;
                 } else {
                     // TODO: any better thing to do here?
                     console.log(result);
@@ -166,14 +171,12 @@ const app = new Vue({
         },
         _loadMenu: function() {
             const self = this;
-            self.loading = true;
             const odoo = self.getOdoo({
                 usage: "app",
                 profile_id: this.profile.id,
             });
             return odoo.call("menu").then(function(result) {
                 self.appmenu = result.data;
-                self.loading = false;
             });
         },
         _clearConfig: function() {

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -255,7 +255,6 @@ export var ScenarioBaseMixin = {
         _global_state_key: function(state_key) {
             return this.usage + "/" + state_key;
         },
-        // TODO: refactor all transitions to state `wait_call` with this call
         wait_call: function(promise, callback) {
             return promise.then(this.on_call_success, this.on_call_error);
         },

--- a/shopfloor_mobile/static/wms/src/services/color_registry.js
+++ b/shopfloor_mobile/static/wms/src/services/color_registry.js
@@ -37,6 +37,10 @@ color_registry.add_theme(
          * selection
          */
         item_selected: "success",
+        /**
+         * spinner
+         */
+        spinner: "#491966",
     },
     "light"
 ); // TODO: we should bave a theme named "coosa" and select it


### PR DESCRIPTION
Global events are now triggered when a request starts and ends.
We hook to these events to display a loading spinner on an overlay that blocks the UI.