### PR TITLE
zone picking: fix check against destination location when unloading

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1048,19 +1048,23 @@ class ZonePicking(Component, ChangePackLotMixin):
                     zone_location, picking_type, buffer_lines, message=error
                 )
             # check if the destination location is not the expected one
-            if location != picking_type.default_location_dest_id:
+            #   - OK if the scanned destination is a child of the current
+            #     destination set on buffer lines
+            #   - To confirm if the scanned destination is not a child of the
+            #     current destination set on buffer lines
+            if not location.is_sublocation_of(buffer_lines.location_dest_id):
                 if not confirmation:
                     return self._response_for_unload_all(
                         zone_location,
                         picking_type,
                         buffer_lines,
                         message=self.msg_store.confirm_location_changed(
-                            picking_type.default_location_dest_id, location
+                            first(buffer_lines.location_dest_id), location
                         ),
                         confirmation_required=True,
                     )
-                # the scanned location is still valid, use it
-                self._write_destination_on_lines(buffer_lines, location)
+            # the scanned location is still valid, use it
+            self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
             moves = buffer_lines.mapped("move_id")
             moves.with_context(_sf_no_backorder=True)._action_done()
@@ -1242,19 +1246,24 @@ class ZonePicking(Component, ChangePackLotMixin):
                     first(buffer_lines),
                     message=self.msg_store.dest_location_not_allowed(),
                 )
-            if location != picking_type.default_location_dest_id:
+            # check if the destination location is not the expected one
+            #   - OK if the scanned destination is a child of the current
+            #     destination set on buffer lines
+            #   - To confirm if the scanned destination is not a child of the
+            #     current destination set on buffer lines
+            if not location.is_sublocation_of(buffer_lines.location_dest_id):
                 if not confirmation:
                     return self._response_for_unload_set_destination(
                         zone_location,
                         picking_type,
                         first(buffer_lines),
                         message=self.msg_store.confirm_location_changed(
-                            picking_type.default_location_dest_id, location
+                            first(buffer_lines.location_dest_id), location
                         ),
                         confirmation_required=True,
                     )
-                # the scanned location is valid, use it
-                self._write_destination_on_lines(buffer_lines, location)
+            # the scanned location is valid, use it
+            self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
             moves = buffer_lines.mapped("move_id")
             moves.with_context(_sf_no_backorder=True)._action_done()

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1224,7 +1224,10 @@ class ZonePicking(Component, ChangePackLotMixin):
         if not picking_type.exists():
             return self._response_for_start(message=self.msg_store.record_not_found())
         package = self.env["stock.quant.package"].browse(package_id)
-        if not package.exists():
+        buffer_lines = self._find_buffer_move_lines(
+            zone_location, picking_type, dest_package=package
+        )
+        if not package.exists() or not buffer_lines:
             move_lines = self._find_location_move_lines(zone_location, picking_type)
             return self._response_for_select_line(
                 zone_location,
@@ -1232,10 +1235,6 @@ class ZonePicking(Component, ChangePackLotMixin):
                 move_lines,
                 message=self.msg_store.record_not_found(),
             )
-
-        buffer_lines = self._find_buffer_move_lines(
-            zone_location, picking_type, dest_package=package
-        )
         search = self.actions_for("search")
         location = search.location_from_scan(barcode)
         if location:

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -119,14 +119,25 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids
-        packing_sublocation = (
+        packing_sublocation1 = (
             self.env["stock.location"]
             .sudo()
             .create(
                 {
-                    "name": "Packing sublocation",
+                    "name": "Packing sublocation-1",
                     "location_id": self.packing_location.id,
-                    "barcode": "PACKING_SUBLOCATION",
+                    "barcode": "PACKING_SUBLOCATIO_1",
+                }
+            )
+        )
+        packing_sublocation2 = (
+            self.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Packing sublocation-2",
+                    "location_id": self.packing_location.id,
+                    "barcode": "PACKING_SUBLOCATIO_2",
                 }
             )
         )
@@ -138,13 +149,14 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
             move_line.product_uom_qty,
             self.free_package,
         )
+        move_line.location_dest_id = packing_sublocation1
         response = self.service.dispatch(
             "unload_set_destination",
             params={
                 "zone_location_id": zone_location.id,
                 "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
-                "barcode": packing_sublocation.barcode,
+                "barcode": packing_sublocation2.barcode,
             },
         )
         self.assert_response_unload_set_destination(
@@ -153,7 +165,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
             picking_type,
             move_line,
             message=self.service.msg_store.confirm_location_changed(
-                picking_type.default_location_dest_id, packing_sublocation
+                packing_sublocation1, packing_sublocation2
             ),
             confirmation_required=True,
         )


### PR DESCRIPTION
Issue 1437

I need more information to reproduce the missing `move_line` in the `unload_set_destination` answer, right now the code does what is expected. That means that the buffer of move lines is empty when the `unload_set_destination` endpoint is called, so that the operator didn't scan anything previously to prepare its buffer.

I added another check to get back the operator on the previous screen in case the buffer is empty, but this case should not happen normally.