### PR TITLE
Add check of scanned dest. location vs move's destination

### DIFF
--- a/shopfloor/models/stock_location.py
+++ b/shopfloor/models/stock_location.py
@@ -20,12 +20,17 @@ class StockLocation(models.Model):
         comodel_name="stock.move.line", compute="_compute_reserved_move_lines",
     )
 
-    def is_sublocation_of(self, others):
-        """Return True if self is a sublocation of at least one other"""
+    def is_sublocation_of(self, others, func=any):
+        """Return True if self is a sublocation of others (or equal)
+
+        By default, it return True if any other is a parent or equal.
+        ``all`` can be passed to ``func`` to require all the other locations
+        to be parent or equal to be True.
+        """
         self.ensure_one()
         # Efficient way to verify that the current location is
         # below one of the other location without using SQL.
-        return any(self.parent_path.startswith(other.parent_path) for other in others)
+        return func(self.parent_path.startswith(other.parent_path) for other in others)
 
     def _get_reserved_move_lines(self):
         return self.env["stock.move.line"].search(

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -941,6 +941,8 @@ class ClusterPicking(Component, ChangePackLotMixin):
             )
         if not scanned_location.is_sublocation_of(
             picking_type.default_location_dest_id
+        ) or not scanned_location.is_sublocation_of(
+            lines.mapped("move_id.location_dest_id"), func=all
         ):
             return self._response_for_unload_all(
                 batch, message=self.msg_store.dest_location_not_allowed()
@@ -1092,8 +1094,11 @@ class ClusterPicking(Component, ChangePackLotMixin):
             return self._response_for_unload_set_destination(
                 batch, package, message=self.msg_store.no_location_found()
             )
+
         if not scanned_location.is_sublocation_of(
             picking_type.default_location_dest_id
+        ) or not scanned_location.is_sublocation_of(
+            lines.mapped("move_id.location_dest_id"), func=all
         ):
             return self._response_for_unload_set_destination(
                 batch, package, message=self.msg_store.dest_location_not_allowed()

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -366,6 +366,8 @@ class LocationContentTransfer(Component):
 
         if not scanned_location.is_sublocation_of(
             self.picking_types.mapped("default_location_dest_id")
+        ) or not scanned_location.is_sublocation_of(
+            move_lines.mapped("move_id.location_dest_id"), func=all
         ):
             return self._response_for_scan_destination_all(
                 pickings, message=self.msg_store.dest_location_not_allowed()
@@ -550,6 +552,10 @@ class LocationContentTransfer(Component):
             )
         if not scanned_location.is_sublocation_of(
             package_level.picking_id.picking_type_id.default_location_dest_id
+        ) or not scanned_location.is_sublocation_of(
+            # beware, package_level.move_id is not always set
+            package_level.move_line_ids.move_id.location_dest_id,
+            func=all,
         ):
             return self._response_for_scan_destination(
                 location,
@@ -617,6 +623,8 @@ class LocationContentTransfer(Component):
             )
         if not scanned_location.is_sublocation_of(
             move_line.picking_id.picking_type_id.default_location_dest_id
+        ) or not scanned_location.is_sublocation_of(
+            move_line.move_id.location_dest_id, func=all
         ):
             return self._response_for_scan_destination(
                 location, move_line, message=self.msg_store.dest_location_not_allowed()

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -175,6 +175,8 @@ class SinglePackTransfer(Component):
             if confirmation:
                 # If the destination of the move would be incoherent
                 # (move line outside of it), we change the moves' destination
+                # TODO in other scenarios, we forbid this. Check if we want
+                # to forbid it as well.
                 if not scanned_location.is_sublocation_of(move.location_dest_id):
                     move.location_dest_id = scanned_location.id
             else:

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -115,7 +115,7 @@ class ZonePicking(Component, ChangePackLotMixin):
         data = self._data_for_move_line(zone_location, picking_type, move_line)
         data["confirmation_required"] = confirmation_required
         return self._response(
-            next_state="set_line_destination", data=data, message=message,
+            next_state="set_line_destination", data=data, message=message
         )
 
     def _response_for_zero_check(
@@ -148,7 +148,7 @@ class ZonePicking(Component, ChangePackLotMixin):
             message = self.msg_store.need_confirmation()
         data = self._data_for_move_lines(zone_location, picking_type, move_lines)
         data["confirmation_required"] = confirmation_required
-        return self._response(next_state="unload_all", data=data, message=message,)
+        return self._response(next_state="unload_all", data=data, message=message)
 
     def _response_for_unload_single(
         self, zone_location, picking_type, move_line, message=None, popup=None
@@ -176,7 +176,7 @@ class ZonePicking(Component, ChangePackLotMixin):
         data = self._data_for_move_line(zone_location, picking_type, move_line)
         data["confirmation_required"] = confirmation_required
         return self._response(
-            next_state="unload_set_destination", data=data, message=message,
+            next_state="unload_set_destination", data=data, message=message
         )
 
     def _data_for_select_picking_type(self, zone_location, picking_types):
@@ -455,7 +455,7 @@ class ZonePicking(Component, ChangePackLotMixin):
             if not move_line:
                 response = self.list_move_lines(zone_location.id, picking_type.id)
                 return self._response(
-                    base_response=response, message=self.msg_store.package_not_found(),
+                    base_response=response, message=self.msg_store.package_not_found()
                 )
         product = search.product_from_scan(barcode)
         if product:
@@ -465,7 +465,7 @@ class ZonePicking(Component, ChangePackLotMixin):
             if not move_line:
                 response = self.list_move_lines(zone_location.id, picking_type.id)
                 return self._response(
-                    base_response=response, message=self.msg_store.product_not_found(),
+                    base_response=response, message=self.msg_store.product_not_found()
                 )
         lot = search.lot_from_scan(barcode)
         if lot:
@@ -473,13 +473,13 @@ class ZonePicking(Component, ChangePackLotMixin):
             if not move_line:
                 response = self.list_move_lines(zone_location.id, picking_type.id)
                 return self._response(
-                    base_response=response, message=self.msg_store.lot_not_found(),
+                    base_response=response, message=self.msg_store.lot_not_found()
                 )
         # barcode not found, get back on 'select_line' screen
         if not move_line:
             response = self.list_move_lines(zone_location.id, picking_type.id)
             return self._response(
-                base_response=response, message=self.msg_store.barcode_not_found(),
+                base_response=response, message=self.msg_store.barcode_not_found()
             )
         return self._response_for_set_line_destination(
             zone_location, picking_type, move_line
@@ -490,11 +490,28 @@ class ZonePicking(Component, ChangePackLotMixin):
     ):
         location_changed = False
         response = None
+
+        # A valid location is a sub-location of the original destination, or a
+        # any sub-location of the picking type's default destination location
+        # if `confirmation is True
         # Ask confirmation to the user if the scanned location is not in the
         # expected ones but is valid (in picking type's default destination)
-        if not location.is_sublocation_of(move_line.location_dest_id) and (
-            not confirmation
-            and location.is_sublocation_of(picking_type.default_location_dest_id)
+        if not location.is_sublocation_of(
+            picking_type.default_location_dest_id
+        ) or not location.is_sublocation_of(
+            move_line.move_id.location_dest_id, func=all
+        ):
+            response = self._response_for_set_line_destination(
+                zone_location,
+                picking_type,
+                move_line,
+                message=self.msg_store.dest_location_not_allowed(),
+            )
+            return (location_changed, response)
+
+        if (
+            not location.is_sublocation_of(move_line.location_dest_id)
+            and not confirmation
         ):
             response = self._response_for_set_line_destination(
                 zone_location,
@@ -506,20 +523,7 @@ class ZonePicking(Component, ChangePackLotMixin):
                 confirmation_required=True,
             )
             return (location_changed, response)
-        # A valid location is a sub-location of the original destination, or a
-        # sub-location of the picking type's default destination location if
-        # `confirmation is True
-        if not location.is_sublocation_of(move_line.location_dest_id) and (
-            confirmation
-            and not location.is_sublocation_of(picking_type.default_location_dest_id)
-        ):
-            response = self._response_for_set_line_destination(
-                zone_location,
-                picking_type,
-                move_line,
-                message=self.msg_store.dest_location_not_allowed(),
-            )
-            return (location_changed, response)
+
         # If no destination package
         if not move_line.result_package_id:
             response = self._response_for_set_line_destination(
@@ -744,7 +748,7 @@ class ZonePicking(Component, ChangePackLotMixin):
 
         # Process the next line
         response = self.list_move_lines(zone_location.id, picking_type.id)
-        return self._response(base_response=response, message=message,)
+        return self._response(base_response=response, message=message)
 
     def is_zero(self, zone_location_id, picking_type_id, move_line_id, zero):
         """Confirm or not if the source location of a move has zero qty
@@ -984,7 +988,7 @@ class ZonePicking(Component, ChangePackLotMixin):
             return self._response_for_unload_single(
                 zone_location, picking_type, first(move_lines)
             )
-        move_lines = self._find_location_move_lines(zone_location, picking_type,)
+        move_lines = self._find_location_move_lines(zone_location, picking_type)
         return self._response_for_select_line(zone_location, picking_type, move_lines)
 
     def _set_destination_all_response(
@@ -992,12 +996,12 @@ class ZonePicking(Component, ChangePackLotMixin):
     ):
         if buffer_lines:
             return self._response_for_unload_all(
-                zone_location, picking_type, buffer_lines, message=message,
+                zone_location, picking_type, buffer_lines, message=message
             )
         move_lines = self._find_location_move_lines(zone_location, picking_type)
         if move_lines:
             return self._response_for_select_line(
-                zone_location, picking_type, move_lines, message=message,
+                zone_location, picking_type, move_lines, message=message
             )
         return self._response_for_start(message=message)
 
@@ -1069,7 +1073,7 @@ class ZonePicking(Component, ChangePackLotMixin):
         else:
             message = self.msg_store.no_location_found()
         return self._set_destination_all_response(
-            zone_location, picking_type, buffer_lines, message=message,
+            zone_location, picking_type, buffer_lines, message=message
         )
 
     def _write_destination_on_lines(self, lines, location):
@@ -1100,7 +1104,7 @@ class ZonePicking(Component, ChangePackLotMixin):
         # more than one remaining move line in the buffer
         if len(buffer_lines) > 1:
             return self._response_for_unload_single(
-                zone_location, picking_type, first(buffer_lines),
+                zone_location, picking_type, first(buffer_lines)
             )
         # only one move line to process in the buffer
         elif len(buffer_lines) == 1:
@@ -1235,7 +1239,11 @@ class ZonePicking(Component, ChangePackLotMixin):
         search = self.actions_for("search")
         location = search.location_from_scan(barcode)
         if location:
-            if not location.is_sublocation_of(picking_type.default_location_dest_id):
+            if not location.is_sublocation_of(
+                picking_type.default_location_dest_id
+            ) or not location.is_sublocation_of(
+                buffer_lines.move_id.location_dest_id, func=all
+            ):
                 return self._response_for_unload_set_destination(
                     zone_location,
                     picking_type,
@@ -1261,7 +1269,7 @@ class ZonePicking(Component, ChangePackLotMixin):
             buffer_lines = self._find_buffer_move_lines(zone_location, picking_type)
             if buffer_lines:
                 return self._response_for_unload_single(
-                    zone_location, picking_type, first(buffer_lines),
+                    zone_location, picking_type, first(buffer_lines)
                 )
             move_lines = self._find_location_move_lines(zone_location, picking_type)
             if move_lines:

--- a/shopfloor/tests/test_location_content_transfer_set_destination_all.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_all.py
@@ -149,6 +149,24 @@ class LocationContentTransferSetDestinationAllCase(LocationContentTransferCommon
             message=self.service.msg_store.dest_location_not_allowed(),
         )
 
+    def test_set_destination_all_dest_location_move_invalid(self):
+        """The scanned destination location is not in the move's dest location"""
+        # if we have at least one move which does not match the scanned location
+        # we forbid the action
+        self.pickings.move_lines[0].location_dest_id = self.shelf1
+        response = self.service.dispatch(
+            "set_destination_all",
+            params={
+                "location_id": self.content_loc.id,
+                "barcode": self.shelf2.barcode,
+            },
+        )
+        self.assert_response_scan_destination_all(
+            response,
+            self.pickings,
+            message=self.service.msg_store.dest_location_not_allowed(),
+        )
+
     def test_go_to_single(self):
         """User used to 'split by lines' button to process line per line"""
         response = self.service.dispatch(

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -111,6 +111,28 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             message=self.service.msg_store.dest_location_not_allowed(),
         )
 
+    def test_set_destination_package_dest_location_move_nok(self):
+        """Scanned destination location not valid (different as move)"""
+        package_level = self.picking1.package_level_ids[0]
+        # if the move related to the package level has a destination
+        # location not a parent or equal to the scanned location,
+        # refuse the action
+        move = package_level.move_line_ids.move_id
+        move.location_dest_id = self.shelf1
+        response = self.service.dispatch(
+            "set_destination_package",
+            params={
+                "location_id": self.content_loc.id,
+                "package_level_id": package_level.id,
+                "barcode": self.shelf2.barcode,
+            },
+        )
+        self.assert_response_scan_destination(
+            response,
+            package_level,
+            message=self.service.msg_store.dest_location_not_allowed(),
+        )
+
     def test_set_destination_package_dest_location_to_confirm(self):
         """Scanned destination location valid, but need a confirmation."""
         package_level = self.picking1.package_level_ids[0]
@@ -212,6 +234,28 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
                 "move_line_id": move_line.id,
                 "quantity": move_line.product_uom_qty,
                 "barcode": customer_location.barcode,
+            },
+        )
+        self.assert_response_scan_destination(
+            response,
+            move_line,
+            message=self.service.msg_store.dest_location_not_allowed(),
+        )
+
+    def test_set_destination_line_dest_location_move_nok(self):
+        """Scanned destination location not valid (different as move)"""
+        move_line = self.picking2.move_line_ids[0]
+        # if the move related to the move line has a destination
+        # location not a parent or equal to the scanned location,
+        # refuse the action
+        move_line.move_id.location_dest_id = self.shelf1
+        response = self.service.dispatch(
+            "set_destination_line",
+            params={
+                "location_id": self.content_loc.id,
+                "move_line_id": move_line.id,
+                "quantity": move_line.product_uom_qty,
+                "barcode": self.shelf2.barcode,
             },
         )
         self.assert_response_scan_destination(

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -71,6 +71,28 @@ class ZonePickingCommonCase(CommonCase):
                 }
             )
         )
+        cls.packing_sublocation_a = (
+            cls.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Packing Sublocation A",
+                    "location_id": cls.packing_location.id,
+                    "barcode": "PACKING_SUBLOCATION_A",
+                }
+            )
+        )
+        cls.packing_sublocation_b = (
+            cls.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Packing Sublocation B",
+                    "location_id": cls.packing_location.id,
+                    "barcode": "PACKING_SUBLOCATION_B",
+                }
+            )
+        )
         cls.product_e = (
             cls.env["product.product"]
             .sudo()

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -131,6 +131,34 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             message=self.service.msg_store.confirm_pack_moved(),
         )
 
+    def test_set_destination_location_move_invalid_location(self):
+        # Confirm the destination with a wrong destination, outside of move's
+        # move line (should not happen)
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_line_ids
+        move_line.location_dest_id = self.packing_sublocation_a
+        move_line.move_id.location_dest_id = self.packing_sublocation_a
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "zone_location_id": zone_location.id,
+                "picking_type_id": picking_type.id,
+                "move_line_id": move_line.id,
+                "barcode": self.packing_sublocation_b.barcode,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": True,
+            },
+        )
+        # Check response
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.dest_location_not_allowed(),
+        )
+
     def test_set_destination_location_no_other_move_line_full_qty(self):
         """Scanned barcode is the destination location.
 

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -115,6 +115,36 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
             message=self.service.msg_store.dest_location_not_allowed(),
         )
 
+    def test_unload_set_destination_location_move_not_allowed(self):
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_line_ids
+        move_line[0].move_id.location_dest_id = self.packing_sublocation_a
+        # set the destination package
+        self.service._set_destination_package(
+            zone_location,
+            picking_type,
+            move_line,
+            move_line.product_uom_qty,
+            self.free_package,
+        )
+        response = self.service.dispatch(
+            "unload_set_destination",
+            params={
+                "zone_location_id": zone_location.id,
+                "picking_type_id": picking_type.id,
+                "package_id": self.free_package.id,
+                "barcode": self.packing_sublocation_b.barcode,
+            },
+        )
+        self.assert_response_unload_set_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.dest_location_not_allowed(),
+        )
+
     def test_unload_set_destination_confirm_location(self):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id


### PR DESCRIPTION
When we scan a location, generally, we have these rules:

* If the scanned location is not a child (or =) of the picking type's
  default destination, reject it
* If the scanned location is not a child (or =) of of the current move
  line's destination, ask for a confirmation

However, we have no check on the move's destination location.

Example
-------

Locations:

Packing Zone
 \- PACK-1
 \- PACK-2

Our transfer has:

* Picking type destination location: Packing Zone
* Move destination location: Packing Zone/PACK-1
* Move line destination location: Packing Zone/PACK-1

Current behavior:

* If we scan "PACK-1", the location is accepted directly
* If we scan "PACK-2", the app asks for a confirmation

If the user confirms PACK-2, we'll have inconsistencies with such
result:

* Move destination location: Packing Zone/PACK-1
* Move line destination location: Packing Zone/PACK-2

Also, the next move in the chain expects to receive goods in "Packing
Zone/PACK-1", so we break the chain.

Expected behavior after this commit:

* If we scan "PACK-1", the location is accepted directly
* If we scan "PACK-2", the location is rejected

Considerations
--------------

This issue was detected in the location content transfer, but it may
happen in the other scenarios, so all of them should be fixed.

Except for "Single Pack Transfer" which was already handling this in a
different way, by updating the move's destination location. I don't
think it is correct, as I doubt the next move in the chain will be
correct then. But I don't want to break a use case that could be used,
so not changing it for now.

In Zone Picking, I simplified a bit the checks on the location: by
checking *first* if we are in the picking type (and in the move
desination now), we can return early and avoid repeating the condition
on the next check.

Issue 1448