### PR TITLE
Checkout edit qty split partial

### DIFF
--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -109,7 +109,7 @@ class StockMoveLine(models.Model):
             pickings = new_picking
         return pickings
 
-    def _check_qty_to_be_done(self, qty_done, split_partial=True):
+    def _check_qty_to_be_done(self, qty_done, split_partial=True, **split_default_vals):
         """Check qty to be done for current move line. Split it if needed.
 
         :param qty_done: qty expected to be done
@@ -133,7 +133,9 @@ class StockMoveLine(models.Model):
             # has to pick some goods from another place because the location
             # contained less items than expected)
             remaining = self.product_uom_qty - qty_done
-            new_line = self.copy({"product_uom_qty": remaining, "qty_done": 0})
+            vals = {"product_uom_qty": remaining, "qty_done": 0}
+            vals.update(split_default_vals)
+            new_line = self.copy(vals)
             # if we didn't bypass reservation update, the quant reservation
             # would be reduced as much as the deduced quantity, which is wrong
             # as we only moved the quantity to a new move line

--- a/shopfloor/tests/test_checkout_select_package_base.py
+++ b/shopfloor/tests/test_checkout_select_package_base.py
@@ -8,7 +8,7 @@ class CheckoutSelectPackageMixin:
             next_state="select_package",
             data={
                 "selected_move_lines": [
-                    self._move_line_data(ml) for ml in selected_lines
+                    self._move_line_data(ml) for ml in selected_lines.sorted()
                 ],
                 "picking": self._picking_summary_data(picking),
                 "packing_info": picking.shopfloor_packing_info if packing_info else "",
@@ -26,7 +26,9 @@ class CheckoutSelectPackageMixin:
     ):
         picking = selected_lines.mapped("picking_id")
         deselected_lines = picking.move_line_ids - selected_lines
-        self.assertEqual(selected_lines.ids, [l.id for l in lines_quantities])
+        self.assertEqual(
+            sorted(selected_lines.ids), sorted([l.id for l in lines_quantities])
+        )
         for line, quantity in lines_quantities.items():
             self.assertEqual(line.qty_done, quantity)
         for line in deselected_lines:


### PR DESCRIPTION
When editing the qty done on checkout/packing scenario
the if the qty is not fully done, the line is split
so we can process the remaining qty into another package.

