### PR TITLE
front: save space for main doc title on small screens

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/screen.js
+++ b/shopfloor_mobile/static/wms/src/components/screen.js
@@ -98,6 +98,7 @@ Vue.component("Screen", {
                 dark
                 app
                 dense
+                :class="{'has-main-doc': !_.isEmpty(info.current_doc)}"
                 >
             <v-app-bar-nav-icon @click.stop="drawer = !drawer" v-if="info.showMenu" />
             <v-toolbar-title v-if="info.title">
@@ -208,6 +209,12 @@ Vue.component("nav-items-extra", {
                     route: {name: "home"},
                 },
                 {
+                    id: "scan-anything",
+                    name: "Scan anything",
+                    icon: "mdi-magnify",
+                    route: {name: "scan_anything"},
+                },
+                {
                     id: "settings",
                     name: "Settings",
                     icon: "mdi-settings-outline",
@@ -236,7 +243,7 @@ Vue.component("nav-items-extra", {
 
 Vue.component("app-bar-actions", {
     template: `
-    <div>
+    <div :class="$options._componentTag">
         <v-btn icon @click="$router.push({'name': 'scan_anything'})" :disabled="this.$route.name=='scan_anything'">
             <v-icon >mdi-magnify</v-icon>
         </v-btn>

--- a/shopfloor_mobile/static/wms/src/css/main.css
+++ b/shopfloor_mobile/static/wms/src/css/main.css
@@ -6,10 +6,8 @@ main.v-content > .v-content__wrap > .header .container {
 }
 
 #app .v-toolbar__content .v-toolbar__title {
-    /* TODO: handle max-width by screen size */
-    /* max-width: 170px; */
     padding-left: 10px;
-    font-size: 1rem;
+    font-size: 0.95rem;
 }
 
 #app.demo_mode header {
@@ -519,4 +517,10 @@ I tested only w/ checkout/select_package for now
 }
 .detail.item-detail-card .v-card__title > span {
     margin-right: 1.2em;
+}
+
+@media screen and (max-width: 320px) {
+    #app header.has-main-doc .app-bar-actions {
+        display: none;
+    }
 }


### PR DESCRIPTION
When the main doc title is in the app header (eg: checkout picking)
the scan anything icon is hidden for screens below 320px width.

Font size for doc title is decreased by 0.05rem which gives even more
space for extra digits (currently 22 max).

The action is now always available in the main menu.