### PR TITLE
shopfloor: fix send_confirmation_email handling from pickings

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -26,14 +26,12 @@ class StockMove(models.Model):
         return False
 
     def _action_done(self, cancel_backorder=False):
-        # Overloaded to send the email when the last move of a picking is validated.
-        # The method 'stock.picking._send_confirmation_email' is called only from
-        # the 'stock.picking.action_done()' method but never when moves are
-        # validated partially through the current method.
+        # Overloaded to ensure that the 'action_done' method of the picking
+        # is called when the last move of a picking is validated.
         moves = super()._action_done(cancel_backorder)
         if not self.env.context.get("_action_done_from_picking"):
             pickings = moves.picking_id
             for picking in pickings:
                 if picking.state == "done":
-                    picking._send_confirmation_email()
+                    picking.action_done()
         return moves

--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -46,12 +46,3 @@ class StockPicking(models.Model):
     def action_done(self):
         self = self.with_context(_action_done_from_picking=True)
         return super().action_done()
-
-    def _send_confirmation_email(self):
-        # Avoid sending the confirmation email twice (one when the
-        # 'picking.action_done()' is called, and one when the last move of this
-        # picking is validated through 'move._action_done()')
-        # We send the confirmation email
-        if self.env.context.get("_action_done_from_picking"):
-            return
-        super()._send_confirmation_email()

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -132,9 +132,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
     def test_set_destination_package_dest_location_ok(self):
         """Scanned destination location valid, moves set to done."""
         package_level = self.picking1.package_level_ids[0]
-        with mock.patch.object(
-            type(self.picking1), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking1), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination_package",
                 params={
@@ -143,7 +141,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
                     "barcode": self.dest_location.barcode,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
         move_lines = self.service._find_transfer_move_lines(self.content_loc)
         self.assert_response_start_single(
             response,
@@ -307,9 +305,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         self.assertEqual(move_line_c.move_id.state, "done")
         # Scan remaining qty (4/10)
         remaining_move_line_c = move_product_c_splitted.move_line_ids
-        with mock.patch.object(
-            type(self.picking2), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking2), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination_line",
                 params={
@@ -319,7 +315,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
                     "barcode": self.dest_location.barcode,
                 },
             )
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
         # Check move line data
         self.assertEqual(remaining_move_line_c.move_id.product_uom_qty, 4)
         self.assertEqual(remaining_move_line_c.product_uom_qty, 0)
@@ -339,9 +335,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         move_line_d = self.picking2.move_line_ids.filtered(
             lambda m: m.product_id == self.product_d
         )
-        with mock.patch.object(
-            type(self.picking2), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking2), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination_line",
                 params={
@@ -356,7 +350,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             self.assertEqual(move_line_d.qty_done, 10)
             self.assertEqual(move_line_d.state, "done")
             self.assertEqual(self.picking2.state, "done")
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
 
 
 class LocationContentTransferSetDestinationXSpecialCase(
@@ -520,9 +514,7 @@ class LocationContentTransferSetDestinationXSpecialCase(
         remaining_move_lines = self.picking.move_line_ids_without_package.filtered(
             lambda ml: ml.state == "assigned"
         )
-        with mock.patch.object(
-            type(self.picking), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking), "action_done") as action_done:
             for ml in remaining_move_lines:
                 self.service.dispatch(
                     "set_destination_line",
@@ -534,11 +526,9 @@ class LocationContentTransferSetDestinationXSpecialCase(
                     },
                 )
             self.assertEqual(self.picking.state, "assigned")
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
         package_level = self.picking.package_level_ids[0]
-        with mock.patch.object(
-            type(self.picking), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking), "action_done") as action_done:
             self.service.dispatch(
                 "set_destination_package",
                 params={
@@ -548,4 +538,4 @@ class LocationContentTransferSetDestinationXSpecialCase(
                 },
             )
             self.assertEqual(self.picking.state, "done")
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -399,9 +399,7 @@ class SinglePackTransferCase(CommonCase):
 
         # now, call the service to proceed with validation of the
         # movement
-        with mock.patch.object(
-            type(self.picking), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking), "action_done") as action_done:
             response = self.service.dispatch(
                 "validate",
                 params={
@@ -409,7 +407,7 @@ class SinglePackTransferCase(CommonCase):
                     "location_barcode": self.shelf2.barcode,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
 
         self.assert_response(
             response,
@@ -471,9 +469,7 @@ class SinglePackTransferCase(CommonCase):
 
         # now, call the service to proceed with validation of the
         # movement
-        with mock.patch.object(
-            type(self.picking), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking), "action_done") as action_done:
             response = self.service.dispatch(
                 "validate",
                 params={
@@ -481,7 +477,7 @@ class SinglePackTransferCase(CommonCase):
                     "location_barcode": self.shelf2.barcode,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
 
         self.assert_response(
             response,
@@ -605,9 +601,7 @@ class SinglePackTransferCase(CommonCase):
 
         # expected destination is 'shelf2', we'll scan shelf1 which must
         # ask a confirmation to the user (it's still in the same picking type)
-        with mock.patch.object(
-            type(self.picking), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking), "action_done") as action_done:
             response = self.service.dispatch(
                 "validate",
                 params={
@@ -615,7 +609,7 @@ class SinglePackTransferCase(CommonCase):
                     "location_barcode": self.shelf1.barcode,
                 },
             )
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
 
         message = self.service.actions_for("message").confirm_location_changed(
             self.shelf2, self.shelf1
@@ -655,9 +649,7 @@ class SinglePackTransferCase(CommonCase):
 
         # expected destination is 'shelf1', we'll scan shelf2 which must
         # ask a confirmation to the user (it's still in the same picking type)
-        with mock.patch.object(
-            type(self.picking), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking), "action_done") as action_done:
             response = self.service.dispatch(
                 "validate",
                 params={
@@ -667,7 +659,7 @@ class SinglePackTransferCase(CommonCase):
                     "confirmation": True,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
 
         self.assert_response(
             response,

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -152,9 +152,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         self.assertEqual(len(moves_before), 1)
         self.assertEqual(len(moves_before.move_line_ids), 1)
         move_line = moves_before.move_line_ids
-        with mock.patch.object(
-            type(self.picking1), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking1), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination",
                 params={
@@ -166,7 +164,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
                     "confirmation": False,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
         # Check picking data
         moves_after = self.picking1.move_lines
         self.assertEqual(moves_before, moves_after)
@@ -206,9 +204,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         move_line = moves_before.move_line_ids
         # we need a destination package if we want to scan a destination location
         move_line.result_package_id = self.free_package
-        with mock.patch.object(
-            type(self.picking3), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking3), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination",
                 params={
@@ -220,7 +216,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
                     "confirmation": False,
                 },
             )
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
         self.assert_response_set_line_destination(
             response,
             zone_location,
@@ -257,9 +253,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         # we need a destination package if we want to scan a destination location
         move_line.result_package_id = self.free_package
         other_move_line = moves_before.move_line_ids[1]
-        with mock.patch.object(
-            type(self.picking4), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking4), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination",
                 params={
@@ -271,7 +265,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
                     "confirmation": False,
                 },
             )
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
         # Check picking data (move has been split in two, 6 done and 4 remaining)
         moves_after = self.picking4.move_lines
         self.assertEqual(len(moves_after), 2)
@@ -320,9 +314,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         move_line = moves_before.move_line_ids[0]
         # we need a destination package if we want to scan a destination location
         move_line.result_package_id = self.free_package
-        with mock.patch.object(
-            type(self.picking4), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking4), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination",
                 params={
@@ -334,7 +326,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
                     "confirmation": False,
                 },
             )
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
         self.assert_response_set_line_destination(
             response,
             zone_location,

--- a/shopfloor/tests/test_zone_picking_unload_all.py
+++ b/shopfloor/tests/test_zone_picking_unload_all.py
@@ -161,9 +161,7 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
             another_package,
         )
         # set destination location for all lines in the buffer
-        with mock.patch.object(
-            type(self.picking5), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking5), "action_done") as action_done:
             response = self.service.dispatch(
                 "set_destination_all",
                 params={
@@ -172,7 +170,7 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
                     "barcode": self.packing_location.barcode,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
         # check data
         self.assertEqual(self.picking5.state, "done")
         # buffer should be empty

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -181,9 +181,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
             move_line.product_uom_qty,
             self.free_package,
         )
-        with mock.patch.object(
-            type(self.picking1), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking1), "action_done") as action_done:
             response = self.service.dispatch(
                 "unload_set_destination",
                 params={
@@ -194,7 +192,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
                     "confirmation": True,
                 },
             )
-            send_confirmation_email.assert_called_once()
+            action_done.assert_called_once()
         # check data
         self.assertEqual(move_line.location_dest_id, packing_sublocation)
         self.assertEqual(move_line.move_id.state, "done")
@@ -226,9 +224,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
                 package_dest,
             )
         # process 1/2 buffer line
-        with mock.patch.object(
-            type(self.picking5), "_send_confirmation_email"
-        ) as send_confirmation_email:
+        with mock.patch.object(type(self.picking5), "action_done") as action_done:
             response = self.service.dispatch(
                 "unload_set_destination",
                 params={
@@ -238,7 +234,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
                     "barcode": self.packing_location.barcode,
                 },
             )
-            send_confirmation_email.assert_not_called()
+            action_done.assert_not_called()
         # check data
         move_line = self.picking5.move_line_ids.filtered(
             lambda l: l.result_package_id == self.free_package


### PR DESCRIPTION
* Confirmation email (and delivery labels) have to be generated when moves are
validated (already effective) and also when the validation is done from the
transfer itself.

* ensure that the 'action_done' method of the picking is called when the
  last move is validated (this will trigger the send_confirmation_email
  and other methods)

Issue 1459