### PR TITLE
Partial fix for 1 issue with package levels

### DIFF
--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -13,10 +13,10 @@ class StockPicking(models.Model):
         help="Technical field. Indicates number of move lines included.",
     )
     shopfloor_display_packing_info = fields.Boolean(
-        related="picking_type_id.shopfloor_display_packing_info",
+        related="picking_type_id.shopfloor_display_packing_info"
     )
     shopfloor_packing_info = fields.Text(
-        string="Packing information", related="partner_id.shopfloor_packing_info",
+        string="Packing information", related="partner_id.shopfloor_packing_info"
     )
 
     @api.depends(
@@ -46,3 +46,8 @@ class StockPicking(models.Model):
     def action_done(self):
         self = self.with_context(_action_done_from_picking=True)
         return super().action_done()
+
+    def _check_entire_pack(self):
+        return super(
+            StockPicking, self.with_context(_check_entire_pack_exclude_done=True)
+        )._check_entire_pack()

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -33,6 +33,7 @@ from . import test_delivery_set_qty_done_pack
 from . import test_delivery_set_qty_done_line
 from . import test_delivery_list_stock_picking
 from . import test_delivery_select
+from . import test_move_action_assign
 from . import test_location_content_transfer_base
 from . import test_location_content_transfer_start
 from . import test_location_content_transfer_set_destination_all

--- a/shopfloor/tests/common.py
+++ b/shopfloor/tests/common.py
@@ -294,7 +294,10 @@ class CommonCase(SavepointCase, ComponentMixin):
         product_locations = {}
         package = None
         if in_package:
-            package = cls.env["stock.quant.package"].create({})
+            if isinstance(in_package, models.BaseModel):
+                package = in_package
+            else:
+                package = cls.env["stock.quant.package"].create({})
         for move in moves:
             key = (move.product_id, location or move.location_id)
             product_locations.setdefault(key, 0)

--- a/shopfloor/tests/test_move_action_assign.py
+++ b/shopfloor/tests/test_move_action_assign.py
@@ -1,0 +1,69 @@
+from .common import CommonCase
+
+
+class TestStockMoveActionAssign(CommonCase):
+    @classmethod
+    def setUpClassVars(cls, *args, **kwargs):
+        super().setUpClassVars(*args, **kwargs)
+        cls.wh = cls.env.ref("stock.warehouse0")
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        cls.wh.sudo().delivery_steps = "pick_pack_ship"
+
+    def test_assign_after_move_done(self):
+        """Ensure we can assign moves after moves in same picking are done"""
+        # Normally in odoo, we can't use _action_assign on a single move.
+        # It is done on the stock.picking only.
+        # In several scenarios, we need to set moves to done individually.
+        # However, some code is not planned to behave in this context,
+        # for instance, StockPicking._check_entire_pack() is called by
+        # StockMove._action_assign() and does not check the state of the
+        # move lines, so it modifies "done" move lines.
+        package = self.env["stock.quant.package"].create({})
+        dest_package1 = self.env["stock.quant.package"].create({})
+        dest_package2 = self.env["stock.quant.package"].create({})
+
+        picking = self._create_picking(
+            picking_type=self.wh.pick_type_id, lines=[(self.product_a, 50)]
+        )
+        self._fill_stock_for_moves(picking.move_lines, in_package=package)
+        picking.action_assign()
+
+        self.assertEqual(picking.state, "assigned")
+        self.assertEqual(picking.package_level_ids.package_id, package)
+
+        # split the move lines in 3, we'll validate 2
+        line1 = picking.move_line_ids
+        line2 = line1.copy({"product_uom_qty": 8})
+        line3 = line1.copy({"product_uom_qty": 12})
+        line1.with_context(bypass_reservation_update=True).product_uom_qty = 30
+
+        line2.qty_done = 8
+        line2.move_id.split_other_move_lines(line2)
+        # we are no longer moving the entire package
+        line2.result_package_id = dest_package1
+        line2.move_id.with_context(_sf_no_backorder=True)._action_done()
+
+        line3.qty_done = 12
+        line3.move_id.split_other_move_lines(line3)
+        # we are no longer moving the entire package
+        line3.result_package_id = dest_package2
+        line3.move_id.with_context(_sf_no_backorder=True)._action_done()
+
+        # At this point, _action_assign() has automatically been called on the
+        # remaining move. At the end of _action_assign(),
+        # StockPicking._check_entire_pack() is called, which, by default, look
+        # the sum of the move lines qties, and if they match a package, it:
+        #
+        # * creates a package level
+        # * updates all the move lines result package with the package,
+        #   including the 'done' lines
+        #
+        # These checks ensure that we prevent this to happen.
+        self.assertEqual(
+            picking.move_lines.mapped("state"), ["done", "done", "assigned"]
+        )
+        self.assertEqual(line2.result_package_id, dest_package1)
+        self.assertEqual(line3.result_package_id, dest_package2)

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -394,5 +394,5 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         )
         # check response
         self.assert_response_unload_all(
-            response, zone_location, picking_type, self.picking5.move_line_ids,
+            response, zone_location, picking_type, self.picking5.move_line_ids.sorted(),
         )


### PR DESCRIPTION
We have 2 main issues with package levels:

1. When we start a transfer that moves a full package, a package level is created. When we change the result package of one of the line linked to the package level, the package level stays around but has no meaning anymore. We should delete it.
2. By calling `StockMove._action_done()` directly instead of calling `StockPicking.action_done()` as expected by Odoo, we introduce some issues related to package levels (method `StockPicking._check_entire_pack()` which won't check the state of the move lines.

The commit contain explanations.


For 1., calling `StockPackageLevel.shallow_unlink()` in every place it could be needed is error-prone. I attempted a commit that automatically handle the package level deletion when we change the result package of a line: https://github.com/camptocamp/wms/commit/5ab3965fc318794cd2534e4d9ea368c8b2ceab88
But it breaks the "change package" actions, which rely on the package level (in fact, it reveals an issue there, since we do not necessarily have a package level, and we still must be able to change the package). Since reworking the package replacement is planned, it will take place at the same time.

For 2., we consider removing all the local calls to `StockMove._action_done()` and reverting to the default behavior of Odoo, that will create a backorder each time. It will not be pretty, but we already had several unexpected issues (`_send_confirmation_email` not called, package level issues, ...) by trying to bypass this, it would be safer. This is a work-around until then.

For now, the PR contains only a work-around for **2.**, as changing 1. may bring new issues.

card 1524