### PR TITLE
Fix and unify picking status check

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -72,7 +72,7 @@ class MessageAction(Component):
     def stock_picking_not_found(self):
         return {
             "message_type": "error",
-            "body": _("This transfer does not exist anymore."),
+            "body": _("This transfer does not exist or is not available anymore."),
         }
 
     def package_not_found(self):
@@ -355,12 +355,18 @@ class MessageAction(Component):
             ),
         }
 
+    def transfer_done_success(self, picking):
+        return {
+            "message_type": "success",
+            "body": _("Transfer {} done").format(picking.name),
+        }
+
     def transfer_confirm_done(self):
         return {
             "message_type": "warning",
             "body": _(
-                "Not all lines have been processed, do you want to "
-                "confirm partial operation ?"
+                "Not all lines have been processed with full quantity. "
+                "Do you confirm partial operation?"
             ),
         }
 

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -277,7 +277,10 @@ class Checkout(Component):
         * select_line: the "normal" case, when the user has to put in pack/move
           lines
         """
-        picking = self.env["stock.picking"].browse(picking_id).exists()
+        picking = self.env["stock.picking"].browse(picking_id)
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_manual_selection(message=message)
         return self._select_picking(picking, "manual_selection")
 
     def _select_lines(self, lines):
@@ -313,10 +316,9 @@ class Checkout(Component):
         screen to change the qty done and destination pack if needed
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
 
         search = self.actions_for("search")
 
@@ -464,10 +466,9 @@ class Checkout(Component):
         assert package_id or move_line_id
 
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
 
         selection_lines = self._lines_to_pack(picking)
         if not selection_lines:
@@ -484,10 +485,9 @@ class Checkout(Component):
         self, picking_id, selected_line_ids, move_line_ids, quantity_func
     ):
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
 
         move_lines = self.env["stock.move.line"].browse(move_line_ids).exists()
 
@@ -689,10 +689,9 @@ class Checkout(Component):
         to close the stock picking
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         search = self.actions_for("search")
 
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -741,10 +740,9 @@ class Checkout(Component):
         * select_line: goes back to selection of lines to work on next lines
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         return self._create_and_assign_new_packaging(picking, selected_lines)
 
@@ -759,10 +757,9 @@ class Checkout(Component):
         * select_line: goes back to selection of lines to work on next lines
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         selected_lines.write(
             {"shopfloor_checkout_done": True, "result_package_id": False}
@@ -786,11 +783,9 @@ class Checkout(Component):
         * select_package: when no package is available
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
-
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         return self._response_for_select_dest_package(picking, lines)
 
@@ -826,10 +821,9 @@ class Checkout(Component):
         * summary: all lines are put in packages
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         search = self.actions_for("search")
         package = search.package_from_scan(barcode)
@@ -848,10 +842,9 @@ class Checkout(Component):
         * summary: all lines are put in packages
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         package = self.env["stock.quant.package"].browse(package_id).exists()
         return self._set_dest_package_from_selection(picking, lines, package)
@@ -863,10 +856,9 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         return self._response_for_summary(picking)
 
     def _get_allowed_packaging(self):
@@ -883,11 +875,9 @@ class Checkout(Component):
         * summary: if the package_id no longer exists
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
-
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
         packaging_list = self._get_allowed_packaging()
         return self._response_for_change_packaging(picking, package, packaging_list)
@@ -900,10 +890,9 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
 
         package = self.env["stock.quant.package"].browse(package_id).exists()
         packaging = self.env["product.packaging"].browse(packaging_id).exists()
@@ -937,10 +926,9 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
 
         package = self.env["stock.quant.package"].browse(package_id).exists()
         line = self.env["stock.move.line"].browse(line_id).exists()
@@ -982,23 +970,16 @@ class Checkout(Component):
         * confirm_done: confirm a partial
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        if not picking.exists():
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_found()
-            )
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
         lines = picking.move_line_ids
         if not confirmation:
             if not all(line.qty_done == line.product_uom_qty for line in lines):
                 return self._response_for_summary(
                     picking,
                     need_confirm=True,
-                    message={
-                        "message_type": "warning",
-                        "body": _(
-                            "Not all lines have been processed with full quantity. "
-                            "Do you confirm partial operation?"
-                        ),
-                    },
+                    message=self.msg_store.transfer_confirm_done(),
                 )
             elif not all(line.shopfloor_checkout_done for line in lines):
                 return self._response_for_summary(
@@ -1011,10 +992,7 @@ class Checkout(Component):
                 )
         picking.action_done()
         return self._response_for_select_document(
-            message={
-                "message_type": "success",
-                "body": _("Transfer {} done").format(picking.name),
-            }
+            message=self.msg_store.transfer_done_success(picking)
         )
 
 

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -1,4 +1,4 @@
-from odoo import fields
+from odoo import _, fields
 from odoo.osv import expression
 from odoo.tools.float_utils import float_is_zero
 
@@ -162,10 +162,14 @@ class Delivery(Component):
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
-            message = "\n".join([
-                _("Package {} belongs to a picking without a valid state.").format(package.name),
-                message,
-            ])
+            message = "\n".join(
+                [
+                    _("Package {} belongs to a picking without a valid state.").format(
+                        package.name
+                    ),
+                    message,
+                ]
+            )
             return self._response_for_deliver(message=message)
         if not lines:
             return self._response_for_deliver(
@@ -222,10 +226,14 @@ class Delivery(Component):
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
-            message = "\n".join([
-                _("Product {} belongs to a picking without a valid state.").format(product.name),
-                message,
-            ])
+            message = "\n".join(
+                [
+                    _("Product {} belongs to a picking without a valid state.").format(
+                        product.name
+                    ),
+                    message,
+                ]
+            )
             return self._response_for_deliver(message=message)
 
         new_picking = fields.first(lines.mapped("picking_id"))
@@ -267,10 +275,14 @@ class Delivery(Component):
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
-            message = "\n".join([
-                _("Lot {} belongs to a picking without a valid state.").format(lot.name),
-                message,
-            ])
+            message = "\n".join(
+                [
+                    _("Lot {} belongs to a picking without a valid state.").format(
+                        lot.name
+                    ),
+                    message,
+                ]
+            )
             return self._response_for_deliver(message=message)
 
         new_picking = fields.first(lines.mapped("picking_id"))

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -147,7 +147,7 @@ class LocationContentTransfer(Component):
     def _domain_recover_pickings(self):
         return [
             ("user_id", "=", self.env.uid),
-            ("state", "in", ("assigned", "partially_available")),
+            ("state", "=", "assigned"),
             ("picking_type_id", "in", self.picking_types.ids),
         ]
 

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -358,17 +358,18 @@ class BaseShopfloorProcess(AbstractComponent):
             )
         return picking_types
 
-    def _check_picking_status(self, picking):
-        """Check if `picking` can be processed.
+    def _check_picking_status(self, pickings):
+        """Check if given pickings can be processed.
 
         If the picking is already done, canceled or didn't belong to the
         expected picking type, a message is returned.
         """
-        if not picking.exists():
-            return self.msg_store.stock_picking_not_found()
-        if picking.state == "done":
-            return self.msg_store.already_done()
-        if picking.state != "assigned":  # the picking must be ready
-            return self.msg_store.stock_picking_not_available(picking)
-        if picking.picking_type_id not in self.picking_types:
-            return self.msg_store.cannot_move_something_in_picking_type()
+        for picking in pickings:
+            if not picking.exists():
+                return self.msg_store.stock_picking_not_found()
+            if picking.state == "done":
+                return self.msg_store.already_done()
+            if picking.state != "assigned":  # the picking must be ready
+                return self.msg_store.stock_picking_not_available(picking)
+            if picking.picking_type_id not in self.picking_types:
+                return self.msg_store.cannot_move_something_in_picking_type()

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -357,3 +357,18 @@ class BaseShopfloorProcess(AbstractComponent):
                 )
             )
         return picking_types
+
+    def _check_picking_status(self, picking):
+        """Check if `picking` can be processed.
+
+        If the picking is already done, canceled or didn't belong to the
+        expected picking type, a message is returned.
+        """
+        if not picking.exists():
+            return self.msg_store.stock_picking_not_found()
+        if picking.state == "done":
+            return self.msg_store.already_done()
+        if picking.state not in ("assigned", "partially_available"):
+            return self.msg_store.stock_picking_not_available(picking)
+        if picking.picking_type_id not in self.picking_types:
+            return self.msg_store.cannot_move_something_in_picking_type()

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -368,7 +368,7 @@ class BaseShopfloorProcess(AbstractComponent):
             return self.msg_store.stock_picking_not_found()
         if picking.state == "done":
             return self.msg_store.already_done()
-        if picking.state not in ("assigned", "partially_available"):
+        if picking.state != "assigned":  # the picking must be ready
             return self.msg_store.stock_picking_not_available(picking)
         if picking.picking_type_id not in self.picking_types:
             return self.msg_store.cannot_move_something_in_picking_type()

--- a/shopfloor/tests/test_checkout_done.py
+++ b/shopfloor/tests/test_checkout_done.py
@@ -46,11 +46,7 @@ class CheckoutDonePartialCase(CheckoutCommonCase):
             response,
             next_state="confirm_done",
             data={"picking": self._stock_picking_data(self.picking, done=True)},
-            message={
-                "message_type": "warning",
-                "body": "Not all lines have been processed with full quantity. "
-                "Do you confirm partial operation?",
-            },
+            message=self.service.msg_store.transfer_confirm_done(),
         )
 
     def test_done_partial_confirm(self):
@@ -65,10 +61,7 @@ class CheckoutDonePartialCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "success",
-                "body": "Transfer {} done".format(self.picking.name),
-            },
+            message=self.service.msg_store.transfer_done_success(self.picking),
         )
 
 
@@ -124,8 +117,5 @@ class CheckoutDoneRawUnpackedCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "success",
-                "body": "Transfer {} done".format(self.picking.name),
-            },
+            message=self.service.msg_store.transfer_done_success(self.picking),
         )

--- a/shopfloor/tests/test_checkout_select.py
+++ b/shopfloor/tests/test_checkout_select.py
@@ -53,11 +53,15 @@ class CheckoutSelectCase(CheckoutCommonCase):
     def test_select_error_not_found(self):
         picking = self._create_picking()
         picking.sudo().unlink()
-        self._test_error(picking, "This transfer does not exist anymore.")
+        self._test_error(
+            picking, self.service.msg_store.stock_picking_not_found()["body"]
+        )
 
     def test_select_error_not_available(self):
         picking = self._create_picking()
-        self._test_error(picking, "Transfer {} is not available.".format(picking.name))
+        self._test_error(
+            picking, self.service.msg_store.stock_picking_not_available(picking)["body"]
+        )
 
     def test_select_error_not_allowed(self):
         picking = self._create_picking(picking_type=self.wh.pick_type_id)

--- a/shopfloor/tests/test_checkout_summary.py
+++ b/shopfloor/tests/test_checkout_summary.py
@@ -2,22 +2,63 @@ from .test_checkout_base import CheckoutCommonCase
 
 
 class CheckoutSummaryCase(CheckoutCommonCase):
-    def test_summary_ok(self):
-        picking = self._create_picking(
+    @classmethod
+    def setUpClassBaseData(cls):
+        super().setUpClassBaseData()
+        cls.picking = cls._create_picking(
             lines=[
-                (self.product_a, 10),
-                (self.product_b, 10),
-                (self.product_c, 10),
-                (self.product_d, 10),
+                (cls.product_a, 10),
+                (cls.product_b, 10),
+                (cls.product_c, 10),
+                (cls.product_d, 10),
             ]
         )
-        response = self.service.dispatch("summary", params={"picking_id": picking.id})
 
+    def test_summary_picking_not_ready(self):
+        response = self.service.dispatch(
+            "summary", params={"picking_id": self.picking.id}
+        )
+        self.assert_response(
+            response,
+            next_state="select_document",
+            data={},
+            message=self.service.msg_store.stock_picking_not_available(self.picking),
+        )
+
+    def test_summary_not_fully_processed(self):
+        self._fill_stock_for_moves(self.picking.move_lines, in_package=True)
+        self.picking.action_assign()
+        # satisfy only few lines
+        for ml in self.picking.move_line_ids[:2]:
+            ml.qty_done = ml.product_uom_qty
+            ml.shopfloor_checkout_done = True
+        response = self.service.dispatch(
+            "summary", params={"picking_id": self.picking.id}
+        )
         self.assert_response(
             response,
             next_state="summary",
             data={
-                "picking": self._stock_picking_data(picking, done=True),
+                "picking": self._stock_picking_data(self.picking, done=True),
+                "all_processed": False,
+            },
+        )
+
+    def test_summary_fully_processed(self):
+        self._fill_stock_for_moves(self.picking.move_lines, in_package=True)
+        self.picking.action_assign()
+        # satisfy only all lines
+        for ml in self.picking.move_line_ids:
+            ml.qty_done = ml.product_uom_qty
+            ml.shopfloor_checkout_done = True
+        response = self.service.dispatch(
+            "summary", params={"picking_id": self.picking.id}
+        )
+        self.assert_response(
+            response,
+            next_state="summary",
+            data={
+                "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": True,
             },
         )

--- a/shopfloor/tests/test_delivery_list_stock_picking.py
+++ b/shopfloor/tests/test_delivery_list_stock_picking.py
@@ -17,9 +17,28 @@ class DeliveryListStockPickingCase(DeliveryCommonCase):
             lines=[(cls.product_a, 10), (cls.product_b, 10)]
         )
 
-    def test_list_stock_picking_ok(self):
-        pickings = self.picking1 | self.picking2
+    def test_list_stock_picking_ko(self):
+        """No picking is ready, no picking to list."""
         response = self.service.dispatch("list_stock_picking", params={})
         self.assert_response_manual_selection(
-            response, pickings=pickings,
+            response, pickings=[],
+        )
+
+    def test_list_stock_picking_ok(self):
+        """Picking ready to list."""
+        # prepare 1st picking
+        self._fill_stock_for_moves(self.picking1.move_lines)
+        self.picking1.action_assign()
+        response = self.service.dispatch("list_stock_picking", params={})
+        # picking1 only available
+        self.assert_response_manual_selection(
+            response, pickings=self.picking1,
+        )
+        # prepare 2nd picking
+        self._fill_stock_for_moves(self.picking2.move_lines)
+        self.picking2.action_assign()
+        response = self.service.dispatch("list_stock_picking", params={})
+        # all pickings available
+        self.assert_response_manual_selection(
+            response, pickings=self.picking1 + self.picking2,
         )

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -78,7 +78,7 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
             "scan_deliver", params={"barcode": "NO VALID BARCODE", "picking_id": None}
         )
         self.assert_response_deliver(
-            response, message={"message_type": "error", "body": "Barcode not found"}
+            response, message=self.service.msg_store.barcode_not_found(),
         )
 
     def test_scan_deliver_error_barcode_not_found_keep_picking(self):
@@ -91,7 +91,7 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
             # if the client was working on a picking (it sends picking_id, then
             # send refreshed data)
             picking=self.picking,
-            message={"message_type": "error", "body": "Barcode not found"},
+            message=self.service.msg_store.barcode_not_found(),
         )
 
     def _test_scan_set_done_ok(self, move_lines, barcode):

--- a/shopfloor/tests/test_delivery_select.py
+++ b/shopfloor/tests/test_delivery_select.py
@@ -16,6 +16,10 @@ class DeliverySelectCase(DeliveryCommonCase):
         cls.picking2 = cls._create_picking(
             lines=[(cls.product_a, 10), (cls.product_b, 10)]
         )
+        cls._fill_stock_for_moves(cls.picking1.move_lines)
+        cls._fill_stock_for_moves(cls.picking2.move_lines)
+        cls.pickings = cls.picking1 | cls.picking2
+        cls.pickings.action_assign()
 
     def test_select_ok(self):
         response = self.service.dispatch(
@@ -24,10 +28,9 @@ class DeliverySelectCase(DeliveryCommonCase):
         self.assert_response_deliver(response, picking=self.picking1)
 
     def test_select_not_found(self):
-        pickings = self.picking1 | self.picking2
         response = self.service.dispatch("select", params={"picking_id": -1})
         self.assert_response_manual_selection(
             response,
-            pickings=pickings,
+            pickings=self.pickings,
             message=self.service.msg_store.stock_picking_not_found(),
         )


### PR DESCRIPTION
During checkout and delivery several users can work on the same pickings at different steps and they can always navigate back and forth between screens. Here we make sure that no matter when actions on picking are called, they always validate its state.