### PR TITLE
Fix location content transfer tests

### DIFF
--- a/shopfloor/tests/test_location_content_transfer_mix.py
+++ b/shopfloor/tests/test_location_content_transfer_mix.py
@@ -32,6 +32,8 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
         cls.wh.sudo().delivery_steps = "pick_pack_ship"
         cls.pack_location = cls.wh.wh_pack_stock_loc_id
         cls.ship_location = cls.wh.wh_output_stock_loc_id
+        # Allows zone picking to process PICK picking type
+        cls.zp_menu.sudo().picking_type_ids += cls.wh.pick_type_id
         # Allows location content transfer to process PACK picking type
         cls.menu.sudo().picking_type_ids = cls.wh.pack_type_id
         cls.wh.pack_type_id.sudo().default_location_dest_id = cls.env.ref(


### PR DESCRIPTION
Tests were broken since c99bc5e0e51fb77907b520e621d193f072ef3bc5
(https://github.com/camptocamp/wms/pull/70)

Ref. 1527