### PR TITLE
zone picking: extract move in new picking and use action_done

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -540,11 +540,10 @@ class ZonePicking(Component):
         move_line.qty_done = quantity
         # if the move has other move lines, it is split to have only this move line
         move_line.move_id.split_other_move_lines(move_line)
-        # set to done (without backorder)
-        move_line.move_id.with_context(_sf_no_backorder=True)._action_done()
         # try to re-assign any split move (in case of partial qty)
         if "confirmed" in move_line.picking_id.move_lines.mapped("state"):
             move_line.picking_id.action_assign()
+        move_line.move_id.extract_and_action_done()
         location_changed = True
         # Zero check
         zero_check = picking_type.shopfloor_zero_check
@@ -1073,7 +1072,7 @@ class ZonePicking(Component):
             self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
             moves = buffer_lines.mapped("move_id")
-            moves.with_context(_sf_no_backorder=True)._action_done()
+            moves.extract_and_action_done()
             message = self.msg_store.buffer_complete()
             buffer_lines = self._find_buffer_move_lines(zone_location, picking_type)
         else:
@@ -1275,7 +1274,7 @@ class ZonePicking(Component):
             self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
             moves = buffer_lines.mapped("move_id")
-            moves.with_context(_sf_no_backorder=True)._action_done()
+            moves.extract_and_action_done()
             buffer_lines = self._find_buffer_move_lines(zone_location, picking_type)
             if buffer_lines:
                 return self._response_for_unload_single(

--- a/shopfloor/tests/test_zone_picking_unload_all.py
+++ b/shopfloor/tests/test_zone_picking_unload_all.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from .test_zone_picking_base import ZonePickingCommonCase
 
 
@@ -197,16 +195,14 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
             another_package,
         )
         # set destination location for all lines in the buffer
-        with mock.patch.object(type(self.picking5), "action_done") as action_done:
-            response = self.service.dispatch(
-                "set_destination_all",
-                params={
-                    "zone_location_id": zone_location.id,
-                    "picking_type_id": picking_type.id,
-                    "barcode": self.packing_location.barcode,
-                },
-            )
-            action_done.assert_called_once()
+        response = self.service.dispatch(
+            "set_destination_all",
+            params={
+                "zone_location_id": zone_location.id,
+                "picking_type_id": picking_type.id,
+                "barcode": self.packing_location.barcode,
+            },
+        )
         # check data
         self.assertEqual(self.picking5.state, "done")
         # buffer should be empty


### PR DESCRIPTION
Calling _action_done() directly on the stock.move while leaving the
stock.picking "assigned" with the other moves already required various
workarounds as it is normally not an expected flow in Odoo.

A previous commit added a method "extract_and_action_done" on the
moves, which extract the move(s) to set to done in its own stock.picking
and call action_done() on it. We ensure it works as intented by the
stock module.

The remaining code for the workarounds (_sf_no_backorder, ...) will be
removed in a subsequent commit.