### PR TITLE
single pack transfer: extract move in new picking and use action_done

### DIFF
--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -202,7 +202,7 @@ class SinglePackTransfer(Component):
         # when writing the destination on the package level, it writes
         # on the move lines
         move.move_line_ids.package_level_id.location_dest_id = scanned_location
-        move._action_done()
+        move.extract_and_action_done()
 
     def cancel(self, package_level_id):
         package_level = self.env["stock.package_level"].browse(package_level_id)

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from odoo.tests.common import Form
 
 from .common import CommonCase
@@ -399,15 +397,13 @@ class SinglePackTransferCase(CommonCase):
 
         # now, call the service to proceed with validation of the
         # movement
-        with mock.patch.object(type(self.picking), "action_done") as action_done:
-            response = self.service.dispatch(
-                "validate",
-                params={
-                    "package_level_id": package_level.id,
-                    "location_barcode": self.shelf2.barcode,
-                },
-            )
-            action_done.assert_called_once()
+        response = self.service.dispatch(
+            "validate",
+            params={
+                "package_level_id": package_level.id,
+                "location_barcode": self.shelf2.barcode,
+            },
+        )
 
         self.assert_response(
             response,
@@ -469,15 +465,14 @@ class SinglePackTransferCase(CommonCase):
 
         # now, call the service to proceed with validation of the
         # movement
-        with mock.patch.object(type(self.picking), "action_done") as action_done:
-            response = self.service.dispatch(
-                "validate",
-                params={
-                    "package_level_id": package_level.id,
-                    "location_barcode": self.shelf2.barcode,
-                },
-            )
-            action_done.assert_called_once()
+        response = self.service.dispatch(
+            "validate",
+            params={
+                "package_level_id": package_level.id,
+                "location_barcode": self.shelf2.barcode,
+            },
+        )
+        self.assertEqual(package_level.picking_id.state, "done")
 
         self.assert_response(
             response,
@@ -666,15 +661,13 @@ class SinglePackTransferCase(CommonCase):
         # expected destination is 'shelf2', we'll scan shelf1 which must
         # ask a confirmation to the user (it's still in the same picking type)
         package_level.location_dest_id = sub_shelf1
-        with mock.patch.object(type(self.picking), "action_done") as action_done:
-            response = self.service.dispatch(
-                "validate",
-                params={
-                    "package_level_id": package_level.id,
-                    "location_barcode": sub_shelf2.barcode,
-                },
-            )
-            action_done.assert_not_called()
+        response = self.service.dispatch(
+            "validate",
+            params={
+                "package_level_id": package_level.id,
+                "location_barcode": sub_shelf2.barcode,
+            },
+        )
 
         message = self.service.actions_for("message").confirm_location_changed(
             sub_shelf1, sub_shelf2
@@ -714,17 +707,15 @@ class SinglePackTransferCase(CommonCase):
 
         # expected destination is 'shelf1', we'll scan shelf2 which must
         # ask a confirmation to the user (it's still in the same picking type)
-        with mock.patch.object(type(self.picking), "action_done") as action_done:
-            response = self.service.dispatch(
-                "validate",
-                params={
-                    "package_level_id": package_level.id,
-                    "location_barcode": self.shelf2.barcode,
-                    # acknowledge the change of destination
-                    "confirmation": True,
-                },
-            )
-            action_done.assert_called_once()
+        response = self.service.dispatch(
+            "validate",
+            params={
+                "package_level_id": package_level.id,
+                "location_barcode": self.shelf2.barcode,
+                # acknowledge the change of destination
+                "confirmation": True,
+            },
+        )
 
         self.assert_response(
             response,


### PR DESCRIPTION
Calling _action_done() directly on the stock.move while leaving the
stock.picking "assigned" with the other moves already required various
workarounds as it is normally not an expected flow in Odoo.

A previous commit added a method "extract_and_action_done" on the
moves, which extract the move(s) to set to done in its own stock.picking
and call action_done() on it. We ensure it works as intented by the
stock module.

The remaining code for the workarounds (_sf_no_backorder, ...) will be
removed in a subsequent commit.