### PR TITLE
shopfloor: remove code related to _action_done usage

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -26,17 +26,6 @@ class StockMove(models.Model):
             return backorder_move
         return False
 
-    def _action_done(self, cancel_backorder=False):
-        # Overloaded to ensure that the 'action_done' method of the picking
-        # is called when the last move of a picking is validated.
-        moves = super()._action_done(cancel_backorder)
-        if not self.env.context.get("_action_done_from_picking"):
-            pickings = moves.picking_id
-            for picking in pickings:
-                if picking.state == "done":
-                    picking.action_done()
-        return moves
-
     def extract_and_action_done(self):
         """Extract the moves in a separate transfer and validate them.
 

--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -36,13 +36,3 @@ class StockPicking(models.Model):
         for move_line in self.mapped("move_line_ids"):
             weight += move_line.product_qty * move_line.product_id.weight
         return weight
-
-    def _create_backorder(self):
-        if self.env.context.get("_sf_no_backorder"):
-            return self.browse()
-        else:
-            return super()._create_backorder()
-
-    def action_done(self):
-        self = self.with_context(_action_done_from_picking=True)
-        return super().action_done()

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -835,7 +835,7 @@ class SinglePackTransferCase(CommonCase):
         picking = move.picking_id
 
         # someone cancel the work started by our operator
-        move._action_done()
+        move.extract_and_action_done()
 
         # now, call the service to cancel
         response = self.service.dispatch(

--- a/shopfloor/tests/test_stock_split.py
+++ b/shopfloor/tests/test_stock_split.py
@@ -145,7 +145,7 @@ class TestStockSplit(SavepointCase):
             move_line.qty_done = move_line.product_uom_qty
             if i % 2:
                 move_line.location_dest_id = dest_location
-        self.pick_move_a.with_context(_sf_no_backorder=True)._action_done()
+        self.pick_move_a.extract_and_action_done()
         self.assertEqual(self.pick_move_a.state, "done")
         # Pack step, we want to split move lines from common source location
         self.assertEqual(self.pack_move_a.state, "assigned")


### PR DESCRIPTION
Depends on:

* [x] common part: https://github.com/camptocamp/wms/pull/72
* [x] single pack transfer: https://github.com/camptocamp/wms/pull/76
* [x] zone_picking: https://github.com/camptocamp/wms/pull/75
* [x] location content transfer: https://github.com/camptocamp/wms/pull/77