### PR TITLE
location transfer: new endpoint to remove a package level

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -459,3 +459,9 @@ class MessageAction(Component):
             "message_type": "error",
             "body": _("New move lines cannot be assigned: canceled."),
         }
+
+    def package_open(self):
+        return {
+            "message_type": "info",
+            "body": _("Package has been opened. You can move partial quantities."),
+        }

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -776,6 +776,41 @@ class LocationContentTransfer(Component):
         move_lines = self._find_transfer_move_lines(location)
         return self._response_for_start_single(move_lines.mapped("picking_id"))
 
+    def dismiss_package_level(self, location_id, package_level_id):
+        """Dismiss the package level.
+
+        The result package of the related move lines is unset, then the package
+        level itself is removed from the picking. This allows to move parts
+        of the package to different locations.
+
+        The user is then redirected to process the next line of the related picking.
+
+        Transitions:
+        * start_single: continue with the next line
+        """
+        location = self.env["stock.location"].browse(location_id)
+        if not location.exists():
+            return self._response_for_start(message=self.msg_store.record_not_found())
+        package_level = self.env["stock.package_level"].browse(package_level_id)
+        if not package_level.exists():
+            move_lines = self._find_transfer_move_lines(location)
+            return self._response_for_start_single(
+                move_lines.mapped("picking_id"),
+                message=self.msg_store.record_not_found(),
+            )
+        move_lines = package_level.move_line_ids
+        move_lines.write(
+            {
+                "result_package_id": False,
+                # ensure all the lines in the package are the next ones to be processed
+                "shopfloor_priority": 1,
+            }
+        )
+        package_level.unlink()
+        return self._response_for_start_single(
+            move_lines.mapped("picking_id"), message=self.msg_store.package_open()
+        )
+
 
 class ShopfloorLocationContentTransferValidator(Component):
     """Validators for the Location Content Transfer endpoints"""
@@ -853,6 +888,12 @@ class ShopfloorLocationContentTransferValidator(Component):
         return {
             "location_id": {"coerce": to_int, "required": True, "type": "integer"},
             "move_line_id": {"coerce": to_int, "required": True, "type": "integer"},
+        }
+
+    def dismiss_package_level(self):
+        return {
+            "location_id": {"coerce": to_int, "required": True, "type": "integer"},
+            "package_level_id": {"coerce": to_int, "required": True, "type": "integer"},
         }
 
 
@@ -950,4 +991,7 @@ class ShopfloorLocationContentTransferValidatorResponse(Component):
         return self._response_schema(next_states={"start", "start_single"})
 
     def stock_out_line(self):
+        return self._response_schema(next_states={"start", "start_single"})
+
+    def dismiss_package_level(self):
         return self._response_schema(next_states={"start", "start_single"})


### PR DESCRIPTION
This allows the user to explode the content of a package and move its
goods to different locations.
Afterwards this means the user will process directly move lines instead
of a package.

Issue 1599