### PR TITLE
location transfer front: Improve handling of multi/single lines/packages

### DIFF
--- a/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
@@ -46,7 +46,7 @@ export var LocationContentTransfer = Vue.component("location-content-transfer", 
                         :card_color="utils.colors.color_for(state_in(['scan_destination', 'scan_destination_all']) ? 'screen_step_done': 'screen_step_todo')"
                         />
 
-                    <v-card v-if="wrapped_context()._type == 'move_line'"
+                    <v-card v-if="wrapped_context()._type == 'move_line' && state_is('scan_destination')"
                             class="pa-2" :color="utils.colors.color_for('screen_step_todo')">
                         <packaging-qty-picker
                             :key="make_state_component_key(['packaging-qty-picker', rec.id])"
@@ -132,23 +132,21 @@ export var LocationContentTransfer = Vue.component("location-content-transfer", 
             const data = this.state.data;
             let res = {
                 has_records: true,
-                records: data.move_lines,
+                records: [].concat(data.move_lines || [], data.package_levels || []),
                 location_src: null,
                 location_dest: null,
                 _multi: true,
-                _type: "move_line",
+                _type: "mix",
             };
             if (_.isEmpty(res.records) && data.move_line) {
                 res.records = [data.move_line];
+                res._type = "move_line";
                 res._multi = false;
-            }
-            if (_.isEmpty(res.records) && data.package_levels) {
-                res.records = data.package_levels;
-                res._type = "pkg_level";
             }
             if (_.isEmpty(res.records) && data.package_level) {
                 res.records = [data.package_level];
                 res._type = "pkg_level";
+                res._multi = false;
             }
             res.has_records = res.records.length > 0;
             res.location_src = res.has_records ? res.records[0].location_src : null;


### PR DESCRIPTION
* On the "scan destination all" screen, show all the move lines and/or
  package levels moved. Before this change, if we have both move lines
  and package levels, it shows only move lines.
* Shows the quantity picker widget only on the "scan_destination"
  screen: showing on scan_destination_all is misleading as we may
  have several lines/packages and anyway would have no effect,
  on "start_single" it has no effect neither.
* Show the "Action" button when we are moving a package too.