### PR TITLE
Rework change of package/lot

### DIFF
--- a/shopfloor/actions/change_package_lot.py
+++ b/shopfloor/actions/change_package_lot.py
@@ -1,4 +1,5 @@
-from odoo import _
+from odoo import _, exceptions
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 from odoo.addons.component.core import Component
 
@@ -24,27 +25,29 @@ class ChangePackageLot(Component):
         #   different, ...)
         # * if we have several packages for the same lot, we can't know which
         #   one the operator is moving, ask to scan a package
-        lot_package_quants = self.env["stock.quant"].search(
+        lot_quants = self.env["stock.quant"].search(
             [
                 ("lot_id", "=", lot.id),
                 ("location_id", "=", move_line.location_id.id),
-                ("package_id", "!=", False),
                 ("quantity", ">", 0),
             ]
         )
-        if move_line.package_id and not lot_package_quants:
-            return response_error_func(
-                move_line, message=self.msg_store.lot_is_not_a_package(lot),
-            )
-        if len(lot_package_quants) == 1:
-            package = lot_package_quants.package_id
-            return self.change_package(
-                move_line, package, response_ok_func, response_error_func
-            )
-        elif len(lot_package_quants) > 1:
+        package_quants = lot_quants.filtered(lambda quant: quant.package_id)
+        unit_quants = lot_quants - package_quants
+
+        if len(package_quants) > 1 or (package_quants and unit_quants):
+            # When we can't know which package to take, ask to scan a package.
+            # If we have both units and package, they have to scan the package
+            # first.
             return response_error_func(
                 move_line,
                 message=self.msg_store.several_packs_in_location(move_line.location_id),
+            )
+        elif len(package_quants) == 1:
+            # change the package directly
+            package = package_quants.package_id
+            return self.change_package(
+                move_line, package, response_ok_func, response_error_func
             )
         return self._change_pack_lot_change_lot(
             move_line, lot, response_ok_func, response_error_func
@@ -53,6 +56,9 @@ class ChangePackageLot(Component):
     def _change_pack_lot_change_lot(
         self, move_line, lot, response_ok_func, response_error_func
     ):
+        def is_lesser(value, other, rounding):
+            return float_compare(value, other, precision_rounding=rounding) == -1
+
         inventory = self.actions_for("inventory")
         product = move_line.product_id
         if lot.product_id != product:
@@ -61,111 +67,142 @@ class ChangePackageLot(Component):
             )
         previous_lot = move_line.lot_id
         # Changing the lot on the move line updates the reservation on the quants
-        move_line.lot_id = lot
+
+        message_parts = []
+
+        values = {"lot_id": lot.id}
+
+        available_quantity = self.env["stock.quant"]._get_available_quantity(
+            product, move_line.location_id, lot_id=lot, strict=True
+        )
+
+        if move_line.package_id:
+            move_line.package_level_id.explode_package()
+            values["package_id"] = False
+
+        to_assign_moves = self.env["stock.move"]
+        if float_is_zero(
+            available_quantity, precision_rounding=product.uom_id.rounding
+        ):
+            quants = self.env["stock.quant"]._gather(
+                product, move_line.location_id, lot_id=lot, strict=True
+            )
+            if quants:
+                # we have quants but they are all reserved by other lines:
+                # unreserve the other lines and reserve them again after
+                unreservable_lines = self.env["stock.move.line"].search(
+                    [
+                        ("lot_id", "=", lot.id),
+                        ("product_id", "=", product.id),
+                        ("location_id", "=", move_line.location_id.id),
+                        ("qty_done", "=", 0),
+                    ]
+                )
+                if not unreservable_lines:
+                    return response_error_func(
+                        move_line,
+                        message=self.msg_store.cannot_change_lot_already_picked(lot),
+                    )
+                available_quantity = sum(unreservable_lines.mapped("product_qty"))
+                to_assign_moves = unreservable_lines.move_id
+                # if we leave the package level, it will try to reserve the same
+                # one again
+                unreservable_lines.package_level_id.explode_package()
+                # unreserve qties of other lines
+                unreservable_lines.unlink()
+            else:
+                # * we have *no* quant:
+                # The lot is not found at all, but the user scanned it, which means
+                # it's an error in the stock data! To allow the user to continue,
+                # we post an inventory to add the missing quantity, and a second
+                # draft inventory to check later
+                inventory.create_stock_correction(
+                    move_line.move_id,
+                    move_line.location_id,
+                    self.env["stock.quant.package"].browse(),
+                    lot,
+                    move_line.product_qty,
+                )
+                inventory.create_control_stock(
+                    move_line.location_id,
+                    move_line.product_id,
+                    move_line.package_id,
+                    move_line.lot_id,
+                    _("Pick: stock issue on lot: {} found in {}").format(
+                        lot.name, move_line.location_id.name
+                    ),
+                )
+                message_parts.append(
+                    _("A draft inventory has been created for control.")
+                )
+
+        # re-evaluate float_is_zero because we may have changed available_quantity
+        if not float_is_zero(
+            available_quantity, precision_rounding=product.uom_id.rounding
+        ) and is_lesser(
+            available_quantity, move_line.product_qty, product.uom_id.rounding
+        ):
+            new_uom_qty = product.uom_id._compute_quantity(
+                available_quantity, move_line.product_uom_id, rounding_method="HALF-UP"
+            )
+            values["product_uom_qty"] = new_uom_qty
+
+        move_line.write(values)
+
+        if "product_uom_qty" in values:
+            # when we change the quantity of the move, the state
+            # will still be "assigned" and be skipped by "_action_assign",
+            # recompute the state to be "partially_available"
+            move_line.move_id._recompute_state()
+
+        # if the new package has less quantities, assign will create new move
+        # lines
+        move_line.move_id._action_assign()
+
+        # Find other available goods for the lines which were using the
+        # lot before...
+        to_assign_moves._action_assign()
 
         message = self.msg_store.lot_replaced_by_lot(previous_lot, lot)
-        # check that we are supposed to have enough of this lot in the source location
-        quant = lot.quant_ids.filtered(lambda q: q.location_id == move_line.location_id)
-        if not quant:
-            # not supposed to have this lot here... (if there is a quant
-            # but not enough quantity we don't care here: user will report
-            # a stock issue)
-            inventory.create_control_stock(
-                move_line.location_id,
-                move_line.product_id,
-                move_line.package_id,
-                move_line.lot_id,
-                _("Pick: stock issue on lot: {} found in {}").format(
-                    lot.name, move_line.location_id.name
-                ),
-            )
-            message["body"] += _(" A draft inventory has been created for control.")
-
+        if message_parts:
+            message["body"] = "{} {}".format(message["body"], " ".join(message_parts))
         return response_ok_func(move_line, message=message)
 
-    def _package_identical_move_lines_qty(self, package, move_lines):
-        grouped_quants = {}
-        for quant in package.quant_ids:
-            grouped_quants.setdefault(quant.product_id, 0)
-            grouped_quants[quant.product_id] += quant.quantity
-
-        grouped_lines = {}
-        for move_line in move_lines:
-            grouped_lines.setdefault(move_line.product_id, 0)
-            grouped_lines[move_line.product_id] += move_line.product_uom_qty
-
-        return grouped_quants == grouped_lines
+    def _package_content_replacement_allowed(self, package, move_line):
+        # we can't replace by a package which doesn't contain the product...
+        return move_line.product_id in package.quant_ids.product_id
 
     def change_package(self, move_line, package, response_ok_func, response_error_func):
-        inventory = self.actions_for("inventory")
-
-        package_level = move_line.package_level_id
-        # several move lines can be moved by the package level, we'll have
-        # to update all of them
-        move_lines = package_level.move_line_ids
-
-        # prevent to replace a package by a package with a different content
-        identical_content = self._package_identical_move_lines_qty(package, move_lines)
-        if not identical_content:
+        # prevent to replace a package by a package that would not satisfy the
+        # move (different product)
+        content_replacement_allowed = self._package_content_replacement_allowed(
+            package, move_line
+        )
+        if not content_replacement_allowed:
             return response_error_func(
                 move_line, message=self.msg_store.package_different_content(package)
             )
 
         previous_package = move_line.package_id
 
-        if package.location_id != move_line.location_id:
-            # the package has been scanned in the current location so we know its
-            # a mistake in the data... fix the quant to move the package here
-            inventory.move_package_quants_to_location(package, move_line.location_id)
-
-        # search a package level which would already move the scanned package
-        reserved_level = (
-            self.env["stock.package_level"].search([("package_id", "=", package.id)])
-            # not possible to search on state
-            .filtered(lambda level: level.state in ("new", "assigned"))
-        )
-        if reserved_level:
-            reserved_level.ensure_one()
-        if reserved_level.is_done:
-            # Not really supposed to happen: if someone sets is_done, the package
-            # should no longer be here! But we have to check this and inform the
-            # user in any case.
+        # /!\ be sure to box the side-effects before calling "replace_package"
+        # in the savepoint, as we catch the error, we must be sure that any
+        # change is rollbacked
+        try:
+            with self.env.cr.savepoint():
+                # if no quantity is available in the package, this call will
+                # raise a UserError, which will revert the savepoint
+                move_line.replace_package(package)
+        except exceptions.UserError as err:
             return response_error_func(
                 move_line,
-                message=self.msg_store.package_already_picked_by(
-                    package, reserved_level.picking_id
-                ),
+                message=self.msg_store.package_change_error(package, err.name),
             )
 
-        # Switch the package with the level which was moving it, as we know
-        # that:
-        # * only one package level at a time is supposed to move a package
-        # * the content of the other package is the same (as we checked the
-        #   content is the same as the current move lines)
-        # * if we left the reserved level with the scanned package, we would
-        #   have 2 levels for the same package and odoo would unreserve the
-        #   move lines as soon as we confirm the current moves
-        # Considering this, we should be safe to interchange the packages
-        if reserved_level:
-            # Ignore updates on quant reservation, which would prevent to switch
-            # 2 packages between 2 assigned package levels: when writing the
-            # package of the second level to the first level, it would unreserve
-            # it because the second level is still using the package.
-            # But here, we know they both available before and must be available after!
-            reserved_level.with_context(bypass_reservation_update=True).replace_package(
-                previous_package
-            )
-            package_level.with_context(bypass_reservation_update=True).replace_package(
-                package
+        if previous_package:
+            message = self.msg_store.package_replaced_by_package(
+                previous_package, package
             )
         else:
-            # when we are not switching packages, we expect the quant
-            # reservations to be aligned
-            package_level.replace_package(package)
-
-        return response_ok_func(
-            move_line,
-            message=self.msg_store.package_replaced_by_package(
-                previous_package, package
-            ),
-        )
+            message = self.msg_store.units_replaced_by_package(package)
+        return response_ok_func(move_line, message=message)

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -432,10 +432,24 @@ class MessageAction(Component):
             ).format(package.name, picking.name),
         }
 
-    def lot_is_not_a_package(self, lot):
+    def units_replaced_by_package(self, new_package):
+        return {
+            "message_type": "success",
+            "body": _("Units replaced by package {}.").format(new_package.name),
+        }
+
+    def package_change_error(self, package, error_msg):
         return {
             "message_type": "error",
-            "body": _("Lot {} is not a package.").format(lot.name),
+            "body": _("Package {} cannot be used: {} ").format(package.name, error_msg),
+        }
+
+    def cannot_change_lot_already_picked(self, lot):
+        return {
+            "message_type": "error",
+            "body": _("Cannot change to lot {} which is entirely picked.").format(
+                lot.name
+            ),
         }
 
     def buffer_complete(self):

--- a/shopfloor/models/stock_package_level.py
+++ b/shopfloor/models/stock_package_level.py
@@ -5,36 +5,15 @@ class StockPackageLevel(models.Model):
     _name = "stock.package_level"
     _inherit = ["stock.package_level", "shopfloor.priority.postpone.mixin"]
 
-    def replace_package(self, new_package):
-        """Replace a package on an assigned package level and related records
-
-        The replacement package must have the same properties (same products
-        and quantities).
-        """
-        if self.state not in ("new", "assigned"):
-            return
-
-        move_lines = self.move_line_ids
-        # the write method on stock.move.line updates the reservation on quants
-        move_lines.package_id = new_package
-        # when a package is set on a line, the destination package is the same
-        # by default
-        move_lines.result_package_id = new_package
-        for quant in new_package.quant_ids:
-            for line in move_lines:
-                if line.product_id == quant.product_id:
-                    line.lot_id = quant.lot_id
-                    line.owner_id = quant.owner_id
-
-        self.package_id = new_package
-
     def shallow_unlink(self):
         """Unlink but keep the moves
+
         A package level has a relation to "move_ids" only when the
         package level was created first from the UI and it created
         its move.
         When we unlink a package level, it deletes the move it created.
         But in some cases, we want to keep the move, e.g.:
+
         * create a package level from the UI to move a package
         * it generates a move for the matching product quantity
         * we use a barcode scenario such as cluster or zone picking

--- a/shopfloor/models/stock_quant_package.py
+++ b/shopfloor/models/stock_quant_package.py
@@ -43,3 +43,36 @@ class StockQuantPackage(models.Model):
         for rec in self:
             if self.search_count([("name", "=", rec.name), ("id", "!=", rec.id)]):
                 raise exceptions.UserError(_("Package name must be unique!"))
+
+    def move_package_to_location(self, dest_location):
+        """Create inventories to move a package to a different location
+
+        It should be called when the package is - in real life - already in
+        the destination. It creates an inventory to remove the package from
+        the source location and a second inventory to place the package
+        in the destination (to reflect the reality).
+
+        The source location is the current location of the package.
+        """
+        quant_values = []
+        # sudo and the key in context activate is_inventory_mode on quants
+        quants = self.quant_ids.sudo().with_context(inventory_mode=True)
+        for quant in quants:
+            quantity = quant.quantity
+            quant.inventory_quantity = 0
+            quant_values.append(
+                self._move_package_quant_move_values(quant, dest_location, quantity)
+            )
+
+        quant_model = self.env["stock.quant"].sudo().with_context(inventory_mode=True)
+        quant_model.create(quant_values)
+
+    def _move_package_quant_move_values(self, quant, location, quantity):
+        return {
+            "product_id": quant.product_id.id,
+            "inventory_quantity": quantity,
+            "location_id": location.id,
+            "lot_id": quant.lot_id.id,
+            "package_id": quant.package_id.id,
+            "owner_id": quant.owner_id.id,
+        }

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -354,7 +354,11 @@ class ClusterPicking(Component):
         """Get the last line picked and put in a pack for this picking"""
         return fields.first(
             picking.move_line_ids.filtered(
-                lambda l: l.qty_done > 0 and l.result_package_id
+                lambda l: l.qty_done > 0
+                and l.result_package_id
+                # if we are moving the entire package, we shouldn't
+                # add stuff inside it, it's not a new package
+                and l.package_id != l.result_package_id
             ).sorted(key="write_date", reverse=True)
         )
 

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -869,14 +869,13 @@ class LocationContentTransfer(Component):
                 message=self.msg_store.record_not_found(),
             )
         move_lines = package_level.move_line_ids
+        package_level.explode_package()
         move_lines.write(
             {
-                "result_package_id": False,
                 # ensure all the lines in the package are the next ones to be processed
                 "shopfloor_priority": 1,
             }
         )
-        package_level.unlink()
         return self._response_for_start_single(
             move_lines.mapped("picking_id"), message=self.msg_store.package_open()
         )

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -2,6 +2,7 @@ from . import test_app
 from . import test_menu
 from . import test_openapi
 from . import test_profile
+from . import test_actions_change_package_lot
 from . import test_actions_data
 from . import test_actions_data_detail
 from . import test_single_pack_transfer

--- a/shopfloor/tests/common.py
+++ b/shopfloor/tests/common.py
@@ -92,6 +92,8 @@ class CommonCase(SavepointCase, ComponentMixin):
             cls.data = work.component(usage="data")
         with cls.work_on_actions(cls) as work:
             cls.data_detail = work.component(usage="data_detail")
+        with cls.work_on_actions(cls) as work:
+            cls.msg_store = work.component(usage="message")
         with cls.work_on_services(cls) as work:
             cls.schema = work.component(usage="schema")
         with cls.work_on_services(cls) as work:
@@ -317,6 +319,32 @@ class CommonCase(SavepointCase, ComponentMixin):
             cls._update_qty_in_location(
                 location, product, qty, package=package, lot=lot
             )
+
+    # used by _create_package_in_location
+    PackageContent = namedtuple(
+        "PackageContent",
+        # recordset of the product,
+        # quantity in float
+        # recordset of the lot (optional)
+        "product quantity lot",
+    )
+
+    def _create_package_in_location(self, location, content):
+        """Create a package and quants in a location
+
+        content is a list of PackageContent
+        """
+        package = self.env["stock.quant.package"].create({})
+        for product, quantity, lot in content:
+            self._update_qty_in_location(
+                location, product, quantity, package=package, lot=lot
+            )
+        return package
+
+    def _create_lot(self, product):
+        return self.env["stock.production.lot"].create(
+            {"product_id": product.id, "company_id": self.env.company.id}
+        )
 
 
 class PickingBatchMixin:

--- a/shopfloor/tests/test_actions_change_package_lot.py
+++ b/shopfloor/tests/test_actions_change_package_lot.py
@@ -1,0 +1,1167 @@
+from odoo.tests.common import Form
+
+from .common import CommonCase
+
+
+class TestActionsChangePackageLot(CommonCase):
+    """Tests covering changing a package on a move line"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with cls.work_on_actions(cls) as work:
+            cls.change_package_lot = work.component(usage="change.package.lot")
+
+    @classmethod
+    def setUpClassVars(cls):
+        super().setUpClassVars()
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.picking_type = cls.wh.out_type_id
+
+    def _create_picking_with_package_level(self, packages):
+        picking_form = Form(self.env["stock.picking"])
+        picking_form.partner_id = self.customer
+        picking_form.origin = "test"
+        picking_form.picking_type_id = self.picking_type
+        picking_form.location_id = self.stock_location
+        picking_form.location_dest_id = self.packing_location
+        for package in packages:
+            with picking_form.package_level_ids_details.new() as move:
+                move.package_id = package
+        picking = picking_form.save()
+        picking.action_confirm()
+        picking.action_assign()
+        return picking
+
+    def assert_quant_reserved_qty(self, move_line, qty_func, package=None, lot=None):
+        domain = [
+            ("location_id", "=", move_line.location_id.id),
+            ("product_id", "=", move_line.product_id.id),
+        ]
+        if package:
+            domain.append(("package_id", "=", package.id))
+        if lot:
+            domain.append(("lot_id", "=", lot.id))
+        quant = self.env["stock.quant"].search(domain)
+        self.assertEqual(quant.reserved_quantity, qty_func())
+
+    def assert_quant_package_qty(self, location, package, qty_func):
+        quant = self.env["stock.quant"].search(
+            [("location_id", "=", location.id), ("package_id", "=", package.id)]
+        )
+        self.assertEqual(quant.quantity, qty_func())
+
+    def assert_control_stock_inventory(self, location, product, lot):
+        inventory = self.env["stock.inventory"].search([], order="id desc", limit=1)
+        self.assertRecordValues(
+            inventory,
+            [
+                {
+                    "state": "draft",
+                    "product_ids": product.ids,
+                    "name": "Pick: stock issue on lot: {} found in {}".format(
+                        lot.name, location.name
+                    ),
+                }
+            ],
+        )
+
+    @staticmethod
+    def unreachable_func(move_line, message=None):
+        raise AssertionError("should not reach this function")
+
+    def test_change_lot_ok(self):
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        source_location = line.location_id
+        new_lot = self._create_lot(self.product_a)
+        # ensure we have our new package in the same location
+        self._update_qty_in_location(source_location, line.product_id, 10, lot=new_lot)
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+        self.assertRecordValues(line, [{"lot_id": new_lot.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+
+    def test_change_lot_less_quantity_ok(self):
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        source_location = line.location_id
+        new_lot = self._create_lot(self.product_a)
+        # ensure we have our new package in the same location
+        self._update_qty_in_location(source_location, line.product_id, 8, lot=new_lot)
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+        self.assertRecordValues(line, [{"lot_id": new_lot.id, "product_qty": 8}])
+        other_line = line.move_id.move_line_ids - line
+        self.assertRecordValues(
+            other_line, [{"lot_id": initial_lot.id, "product_qty": 2}]
+        )
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 2, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+
+    def test_change_lot_zero_quant_ok(self):
+        """No quant in the location for the scanned lot
+
+        As the user scanned it, it's an inventory error.
+        We expect a new posted inventory that updates the quantity.
+        And another control one.
+        """
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        new_lot = self._create_lot(self.product_a)
+        expected_message = self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+        expected_message["body"] += " A draft inventory has been created for control."
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(line, [{"lot_id": new_lot.id, "product_qty": 10}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+
+    def test_change_lot_package_explode_ok(self):
+        """Scan a lot on units replacing a package"""
+        initial_lot = self._create_lot(self.product_a)
+        package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
+        )
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.assertEqual(line.lot_id, initial_lot)
+        self.assertEqual(line.package_id, package)
+
+        new_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=new_lot)
+        expected_message = self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(
+            line,
+            [
+                {
+                    "lot_id": new_lot.id,
+                    "product_qty": 10,
+                    "package_id": False,
+                    "package_level_id": False,
+                }
+            ],
+        )
+
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+
+    def test_change_lot_reserved_qty_ok(self):
+        """Scan a lot already reserved by other lines
+
+        It should unreserve the other line, use the lot for the current line,
+        and re-reserve the other move.
+        """
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.assertEqual(line.lot_id, initial_lot)
+
+        new_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=new_lot)
+        picking2 = self._create_picking(lines=[(self.product_a, 10)])
+        picking2.action_assign()
+        line2 = picking2.move_line_ids
+        self.assertEqual(line2.lot_id, new_lot)
+
+        expected_message = self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(line, [{"lot_id": new_lot.id, "product_qty": 10}])
+        # line has been re-created
+        line2 = picking2.move_line_ids
+        self.assertRecordValues(line2, [{"lot_id": initial_lot.id, "product_qty": 10}])
+
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+        self.assert_quant_reserved_qty(
+            line2, lambda: line2.product_qty, lot=initial_lot
+        )
+
+    def test_change_lot_reserved_partial_qty_ok(self):
+        """Scan a lot already reserved by other lines and can only be reserved
+        partially
+
+        It should unreserve the other line, use the lot for the current line,
+        and re-reserve the other move. The quantity for the current line must
+        be adapted to the available
+        """
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.assertEqual(line.lot_id, initial_lot)
+
+        new_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 8, lot=new_lot)
+        picking2 = self._create_picking(lines=[(self.product_a, 8)])
+        picking2.action_assign()
+        line2 = picking2.move_line_ids
+        self.assertEqual(line2.lot_id, new_lot)
+
+        expected_message = self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(line, [{"lot_id": new_lot.id, "product_qty": 8}])
+        other_line = picking.move_line_ids - line
+        self.assertRecordValues(
+            other_line, [{"lot_id": initial_lot.id, "product_qty": 2}]
+        )
+        # line has been re-created
+        line2 = picking2.move_line_ids
+        self.assertRecordValues(line2, [{"lot_id": initial_lot.id, "product_qty": 8}])
+
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+        # both line2 and the line for the 2 remaining will re-reserve the initial lot
+        self.assert_quant_reserved_qty(
+            other_line,
+            lambda: line2.product_qty + other_line.product_qty,
+            lot=initial_lot,
+        )
+
+    def test_change_lot_reserved_qty_done_error(self):
+        """Scan a lot already reserved by other *picked* lines
+
+        Cannot "steal" lot from picked lines
+        """
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.assertEqual(line.lot_id, initial_lot)
+
+        new_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=new_lot)
+        picking2 = self._create_picking(lines=[(self.product_a, 10)])
+        picking2.action_assign()
+        line2 = picking2.move_line_ids
+        self.assertEqual(line2.lot_id, new_lot)
+        line2.qty_done = 10.0
+
+        expected_message = self.msg_store.cannot_change_lot_already_picked(new_lot)
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            self.unreachable_func,
+            # failure callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+        )
+
+        # no changes
+        self.assertRecordValues(line, [{"lot_id": initial_lot.id, "product_qty": 10}])
+        self.assertRecordValues(
+            line2, [{"lot_id": new_lot.id, "product_qty": 10, "qty_done": 10.0}]
+        )
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=initial_lot)
+        self.assert_quant_reserved_qty(line2, lambda: line2.product_qty, lot=new_lot)
+
+    def test_change_lot_different_location_ok(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        new_lot = self._create_lot(self.product_a)
+        # ensure we have our new package in a different location
+        self._update_qty_in_location(self.shelf2, line.product_id, 10, lot=new_lot)
+        expected_message = self.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
+        expected_message["body"] += " A draft inventory has been created for control."
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(line, [{"lot_id": new_lot.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
+        self.assert_control_stock_inventory(self.shelf1, line.product_id, new_lot)
+
+    def test_change_lot_in_several_packages_error(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
+        )
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        # create 2 packages for the same new lot in the same location
+        new_lot = self._create_lot(self.product_a)
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, new_lot)]
+        )
+        self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, new_lot)]
+        )
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            self.unreachable_func,
+            # failure callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.several_packs_in_location(self.shelf1)
+            ),
+        )
+
+    def test_change_lot_in_package_ok(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
+        )
+        # ensure we have our new package in the same location
+        new_lot = self._create_lot(self.product_a)
+        new_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=new_lot)]
+        )
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message,
+                self.msg_store.package_replaced_by_package(
+                    initial_package, new_package
+                ),
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+        self.assertRecordValues(
+            line,
+            [
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "lot_id": new_lot.id,
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_lot_in_package_no_initial_package_ok(self):
+        self.product_a.tracking = "lot"
+        initial_lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
+        # ensure we have our new package in the same location
+        new_lot = self._create_lot(self.product_a)
+        new_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=new_lot)]
+        )
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.change_package_lot.change_lot(
+            line,
+            new_lot,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.units_replaced_by_package(new_package)
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+        self.assertRecordValues(
+            line,
+            [
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "lot_id": new_lot.id,
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_pack_different_content_error(self):
+        # create the initial package, that will be reserved first
+        initial_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, lot=None),
+                self.PackageContent(self.product_b, 10, lot=None),
+            ],
+        )
+        picking = self._create_picking_with_package_level(initial_package)
+        # create a new package in the same location
+        # with a different content
+        new_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_b, 8, lot=None)]
+        )
+
+        lines = picking.move_line_ids
+        # try to use the new package, which doesn't contain our product,
+        # cannot be changed
+        self.change_package_lot.change_package(
+            lines[0],
+            new_package,
+            # success callback
+            self.unreachable_func,
+            # failure callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.package_different_content(new_package)
+            ),
+        )
+
+    def test_change_pack_multi_content_with_lot(self):
+        """Switch package for a line which was part of a multi-products package
+
+        We have a move line which is part of a package with more than one
+        product and the other product is moved by another move line.
+
+        We want to pick the goods for product A in a different package. What
+        should happen is:
+
+        * the package level is exploded, as we will no longer move the entire
+          package
+        * the move line for product A should now use the new package, and be
+          updated with the lot of the package
+        * the move line for the other product should keep the other package, if
+          the user want to change the package for the other product too, they
+          can do it when they pick it
+        """
+        (self.product_a + self.product_b).tracking = "lot"
+        # create a package with 2 products tracked by lot, stored in shelf1
+        # this package is reserved first on the move line
+        initial_lot_a = self._create_lot(self.product_a)
+        initial_lot_b = self._create_lot(self.product_b)
+        initial_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, initial_lot_a),
+                self.PackageContent(self.product_b, 10, initial_lot_b),
+            ],
+        )
+
+        # create and reserve our transfer using the initial package
+        picking = self._create_picking_with_package_level(initial_package)
+
+        lines = picking.move_line_ids
+
+        # create a second package with the same content, which will be used
+        # as replacement
+        new_lot_a = self._create_lot(self.product_a)
+        new_lot_b = self._create_lot(self.product_b)
+        new_package = self._create_package_in_location(
+            self.shelf1,
+            [
+                self.PackageContent(self.product_a, 10, new_lot_a),
+                self.PackageContent(self.product_b, 10, new_lot_b),
+            ],
+        )
+        line1, line2 = lines
+        self.change_package_lot.change_package(
+            line1,
+            new_package,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message,
+                self.msg_store.package_replaced_by_package(
+                    initial_package, new_package
+                ),
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+        self.assertRecordValues(
+            line1,
+            [
+                {
+                    "package_id": new_package.id,
+                    # we are no longer moving an entire package
+                    "result_package_id": False,
+                    "lot_id": new_lot_a.id,
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertRecordValues(
+            line2,
+            [
+                {
+                    "package_id": initial_package.id,
+                    # we are no longer moving an entire package
+                    "result_package_id": False,
+                    "lot_id": initial_lot_b.id,
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line1, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line2, lambda: line2.product_qty, package=initial_package
+        )
+        self.assert_quant_reserved_qty(
+            line1, lambda: line1.product_qty, package=new_package
+        )
+        self.assert_quant_reserved_qty(line2, lambda: 0, package=new_package)
+
+    def test_change_pack_different_location(self):
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        # put a package in shelf2 in the system, but we assume that in real,
+        # the operator put it in shelf1
+        new_package = self._create_package_in_location(
+            self.shelf2, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        # when the operator wants to pick the initial package, in shelf1, the new
+        # package is in front of the other so they want to change the package
+        self.change_package_lot.change_package(
+            line,
+            new_package,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message,
+                self.msg_store.package_replaced_by_package(
+                    initial_package, new_package
+                ),
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(
+            line, [{"package_id": new_package.id, "result_package_id": new_package.id}]
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        # check that reservations have been updated, the new package is not
+        # supposed to be in shelf2 anymore, and we should have no reserved qty
+        # for the initial package anymore
+        self.assert_quant_package_qty(self.shelf2, new_package, lambda: 0)
+        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_pack_different_location_reserved_package(self):
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.assertEqual(line.package_id, initial_package)
+
+        # put a package in shelf2 in the system, but we assume that in real,
+        # the operator put it in shelf1
+        new_package = self._create_package_in_location(
+            self.shelf2, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking2 = self._create_picking(lines=[(self.product_a, 10)])
+        picking2.action_assign()
+        line2 = picking2.move_line_ids
+        self.assertEqual(line2.package_id, new_package)
+
+        # When the operator wants to pick the initial package, in shelf1, the new
+        # package is in front of the other so they want to change the package.
+        # The new package was supposed to be in shelf2 but is in fact in
+        # shelf1.
+        # An inventory must move it in shelf1 before we change the package on the line.
+        # Line2 must be unreserved and reserved again.
+        self.change_package_lot.change_package(
+            line,
+            new_package,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message,
+                self.msg_store.package_replaced_by_package(
+                    initial_package, new_package
+                ),
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        # line2 has been re-created
+        line2 = picking2.move_line_ids
+        self.assertRecordValues(
+            line + line2,
+            [
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "location_id": self.shelf1.id,
+                    "product_qty": 10.0,
+                },
+                {
+                    "package_id": initial_package.id,
+                    "result_package_id": initial_package.id,
+                    "location_id": self.shelf1.id,
+                    "product_qty": 10.0,
+                },
+            ],
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+        self.assertRecordValues(
+            line2.package_level_id, [{"package_id": initial_package.id}]
+        )
+        # check that reservations have been updated, the new package is not
+        # supposed to be in shelf2 anymore, and we should have no reserved qty
+        # for the initial package anymore
+        self.assert_quant_package_qty(self.shelf2, new_package, lambda: 0)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+        self.assert_quant_reserved_qty(
+            line2, lambda: line2.product_qty, package=initial_package
+        )
+
+    def test_change_pack_different_location_reserved_package_qty_done(self):
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        self.assertEqual(line.package_id, initial_package)
+
+        # put a package in shelf2 in the system, but we assume that in real,
+        # the operator put it in shelf1
+        new_package = self._create_package_in_location(
+            self.shelf2, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking2 = self._create_picking(lines=[(self.product_a, 10)])
+        picking2.action_assign()
+        line2 = picking2.move_line_ids
+        self.assertEqual(line2.package_id, new_package)
+        line2.qty_done = 10.0
+
+        # The new package was supposed to be in shelf2 but is in fact in shelf1.
+        # The package has already been picked in shelf2 (unlikely to happen...
+        # still we have to handle it). Forbid to pick.
+        expected_message = self.msg_store.package_change_error(
+            new_package,
+            "Package {} has been partially picked in another location".format(
+                new_package.display_name, line.product_id.display_name
+            ),
+        )
+        self.change_package_lot.change_package(
+            line,
+            new_package,
+            # success callback
+            self.unreachable_func,
+            # failure callback
+            lambda move_line, message=None: self.assertEqual(message, expected_message),
+        )
+
+        # line2 has been re-created
+        line2 = picking2.move_line_ids
+        self.assertRecordValues(
+            line + line2,
+            [
+                {
+                    "package_id": initial_package.id,
+                    "result_package_id": initial_package.id,
+                    "location_id": self.shelf1.id,
+                    "product_qty": 10.0,
+                },
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "location_id": self.shelf2.id,
+                    "product_qty": 10.0,
+                },
+            ],
+        )
+        # no change
+        self.assertRecordValues(
+            line.package_level_id, [{"package_id": initial_package.id}]
+        )
+        self.assertRecordValues(
+            line2.package_level_id, [{"package_id": new_package.id}]
+        )
+        self.assert_quant_package_qty(self.shelf2, new_package, lambda: 10.0)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=initial_package
+        )
+        self.assert_quant_reserved_qty(
+            line2, lambda: line2.product_qty, package=new_package
+        )
+
+    def test_change_pack_lot_change_pack_less_qty_ok(self):
+        initial_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 100, lot=None)]
+        )
+
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+
+        self.assertRecordValues(
+            line,
+            [
+                {
+                    "package_id": initial_package.id,
+                    # since we don't move the entire package (10 out of 100), no
+                    # result package
+                    "result_package_id": False,
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertFalse(line.package_level_id)
+
+        # ensure we have our new package in the same location
+        new_package = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        self.change_package_lot.change_package(
+            line,
+            new_package,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message,
+                self.msg_store.package_replaced_by_package(
+                    initial_package, new_package
+                ),
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+        self.assertRecordValues(
+            line,
+            [
+                {
+                    "package_id": new_package.id,
+                    "result_package_id": new_package.id,
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
+
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
+        self.assert_quant_reserved_qty(
+            line, lambda: line.product_qty, package=new_package
+        )
+
+    def test_change_pack_steal_from_other_move_line(self):
+        """Exchange pack with another line
+
+        When we scan the package used on another line not picked yet (qty_done
+        == 0), we unreserve the other line and use its package. The other line
+        is reserved again and should reserve the package used initially on our
+        move line.
+        """
+        # create 2 picking, each with its own package
+        package1 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking1 = self._create_picking_with_package_level(package1)
+        self.assertEqual(picking1.move_line_ids.package_id, package1)
+
+        package2 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking2 = self._create_picking_with_package_level(package2)
+        self.assertEqual(picking2.move_line_ids.package_id, package2)
+
+        line = picking1.move_line_ids
+
+        # We "steal" package2 for the picking1
+        self.change_package_lot.change_package(
+            line,
+            package2,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.package_replaced_by_package(package1, package2)
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(
+            picking1.move_line_ids,
+            [
+                {
+                    "package_id": package2.id,
+                    "result_package_id": package2.id,
+                    "state": "assigned",
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertRecordValues(
+            picking2.move_line_ids,
+            [
+                {
+                    "package_id": package1.id,
+                    "result_package_id": package1.id,
+                    "state": "assigned",
+                    "product_qty": 10.0,
+                }
+            ],
+        )
+        self.assertRecordValues(
+            picking1.package_level_ids,
+            [{"package_id": package2.id, "state": "assigned"}],
+        )
+        self.assertRecordValues(
+            picking2.package_level_ids,
+            [{"package_id": package1.id, "state": "assigned"}],
+        )
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(
+            picking1.move_line_ids,
+            lambda: picking1.move_line_ids.product_qty,
+            package=package2,
+        )
+        self.assert_quant_reserved_qty(
+            picking2.move_line_ids,
+            lambda: picking2.move_line_ids.product_qty,
+            package=package1,
+        )
+
+    def test_other_line_with_qty_done(self):
+        """Try to exchange pack with other line with qty_done
+
+        When we scan the package used on another line which has been picked
+        (qty_done > 0), do not unreserve the other line.
+        """
+        # create 2 picking, each with its own package
+        package1 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking1 = self._create_picking_with_package_level(package1)
+        self.assertEqual(picking1.move_line_ids.package_id, package1)
+
+        package2 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking2 = self._create_picking_with_package_level(package2)
+        self.assertEqual(picking2.move_line_ids.package_id, package2)
+
+        line1 = picking1.move_line_ids
+        line2 = picking2.move_line_ids
+        line2.qty_done = 10
+
+        self.change_package_lot.change_package(
+            line1,
+            package2,
+            # success callback
+            self.unreachable_func,
+            # failure callback
+            lambda move_line, message=None: self.assertEqual(
+                message,
+                self.msg_store.package_change_error(
+                    package2,
+                    "Package {} does not contain available product {},"
+                    " cannot replace package.".format(
+                        package2.display_name, line1.product_id.display_name
+                    ),
+                ),
+            ),
+        )
+
+        # did not change
+        self.assertRecordValues(
+            picking1.move_line_ids,
+            [
+                {
+                    "package_id": package1.id,
+                    "result_package_id": package1.id,
+                    "state": "assigned",
+                }
+            ],
+        )
+        self.assertRecordValues(
+            picking2.move_line_ids,
+            [
+                {
+                    "package_id": package2.id,
+                    "result_package_id": package2.id,
+                    "state": "assigned",
+                }
+            ],
+        )
+        self.assertRecordValues(
+            picking1.package_level_ids,
+            [{"package_id": package1.id, "state": "assigned"}],
+        )
+        self.assertRecordValues(
+            picking2.package_level_ids,
+            [{"package_id": package2.id, "state": "assigned"}],
+        )
+        # check that reservations have been updated
+        self.assert_quant_reserved_qty(
+            picking1.move_line_ids,
+            lambda: picking1.move_line_ids.product_qty,
+            package=package1,
+        )
+        self.assert_quant_reserved_qty(
+            picking2.move_line_ids,
+            lambda: picking2.move_line_ids.product_qty,
+            package=package2,
+        )
+
+    def test_package_partial(self):
+        """Try to exchange pack with a package partially picked
+
+        When we scan the package used on another line which has been picked
+        (qty_done > 0), but the new package still has unreserved quantity:
+
+        * the current line is updated for the remaining unreserved quantity
+        * a new line is created for the remaining
+        * the other already picked line is untouched
+        """
+        # create 2 picking, each with its own package
+        package1 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+        picking1 = self._create_picking_with_package_level(package1)
+        line1 = picking1.move_line_ids
+        self.assertEqual(line1.package_id, package1)
+
+        package2 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
+        )
+
+        # take partially in package2 (no package level as moving partial
+        # package)
+        picking2 = self._create_picking(lines=[(self.product_a, 8)])
+        picking2.action_assign()
+        line2 = picking2.move_line_ids
+        self.assertEqual(line2.package_id, package2)
+
+        # this line is picked, should not be changed, but we still have
+        # 2 units in package2
+        line2.qty_done = line2.product_qty
+
+        self.change_package_lot.change_package(
+            line1,
+            package2,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.package_replaced_by_package(package1, package2)
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(
+            line1,
+            [
+                {
+                    "package_id": package2.id,
+                    # not moved entirely by this transfer
+                    "result_package_id": False,
+                    "state": "assigned",
+                    # as the remaining was 2 units, the line is
+                    # changed to take only 2
+                    "product_qty": 2.0,
+                }
+            ],
+        )
+        self.assertRecordValues(
+            # this line should be unchanged
+            line2,
+            [
+                {
+                    "package_id": package2.id,
+                    # not moved entirely by this transfer
+                    "result_package_id": False,
+                    "state": "assigned",
+                    "product_qty": 8.0,
+                }
+            ],
+        )
+
+        # A new line has been created for the quantity the line1
+        # couldn't take in package2. It will take the first goods
+        # available, which happen to be package1 (which was unreserved
+        # when we changed the package of line1).
+        remaining_line = picking1.move_line_ids - line1
+        self.assertRecordValues(
+            remaining_line,
+            [
+                {
+                    "package_id": package1.id,
+                    # not moved entirely by this transfer
+                    "result_package_id": False,
+                    "state": "assigned",
+                    # remaining qty for the 1st move
+                    "product_qty": 8.0,
+                }
+            ],
+        )
+
+        # the package1 must have only 8 reserved, for the remaining
+        # of the line
+        self.assertEqual(package1.quant_ids.reserved_quantity, 8)
+        self.assertEqual(package2.quant_ids.reserved_quantity, 10)
+
+        # no package is moved entirely at once
+        self.assertFalse(picking1.package_level_ids)
+        self.assertFalse(picking2.package_level_ids)
+
+    def test_package_2_lines_1_move(self):
+        """Keep picked move line if we have 2 lines on a move
+
+        Create a situation where we have 2 move lines on a move, with different
+        packages, 1 one of them is already picked (qty_done > 0), we change the
+        package on the second one: the first one must not be changed.
+        """
+        package1 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 4, lot=None)]
+        )
+        package2 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 8, lot=None)]
+        )
+
+        # take partially in package2 (no package level as moving partial
+        # package)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        move = picking.move_lines
+        line1, line2 = move.move_line_ids
+        self.assertEqual(line1.package_id, package1)
+        self.assertEqual(line2.package_id, package2)
+
+        # package to switch to
+        package3 = self._create_package_in_location(
+            self.shelf1, [self.PackageContent(self.product_a, 8, lot=None)]
+        )
+
+        # this line is picked and must not be changed
+        line1.qty_done = line1.product_qty
+
+        # as we change for package2, the line should get only the remaining
+        # part of the package
+
+        self.change_package_lot.change_package(
+            line2,
+            package3,
+            # success callback
+            lambda move_line, message=None: self.assertEqual(
+                message, self.msg_store.package_replaced_by_package(package2, package3)
+            ),
+            # failure callback
+            self.unreachable_func,
+        )
+
+        self.assertRecordValues(
+            line1 | line2,
+            [
+                {
+                    "package_id": package1.id,
+                    "state": "assigned",
+                    "product_qty": 4.0,
+                    "qty_done": 4.0,
+                },
+                {
+                    "package_id": package3.id,
+                    "state": "assigned",
+                    "product_qty": 6.0,
+                    "qty_done": 0.0,
+                },
+            ],
+        )
+
+        # package1 is moved entirely
+        self.assertTrue(line1.package_level_id)
+        # package2 is not moved entirely
+        self.assertFalse(line2.package_level_id)
+
+        # the package1 must have only 8 reserved, for the remaining
+        # of the line
+        self.assertEqual(package1.quant_ids.reserved_quantity, 4)
+        self.assertEqual(package2.quant_ids.reserved_quantity, 0)
+        self.assertEqual(package3.quant_ids.reserved_quantity, 6)

--- a/shopfloor/tests/test_cluster_picking_change_pack_lot.py
+++ b/shopfloor/tests/test_cluster_picking_change_pack_lot.py
@@ -1,36 +1,18 @@
-from collections import namedtuple
-
-from odoo.tests.common import Form
-
 from .test_cluster_picking_base import ClusterPickingCommonCase
 
 
-class ClusterPickingChangePackLotCommon(ClusterPickingCommonCase):
+class ClusterPickingChangePackLotCase(ClusterPickingCommonCase):
+    """Tests covering the /change_pack_lot endpoint
 
-    # used by _create_package_in_location
-    PackageContent = namedtuple(
-        "PackageContent",
-        # recordset of the product,
-        # quantity in float
-        # recordset of the lot (optional)
-        "product quantity lot",
-    )
+    Only simple cases are tested to check the flow of responses on success and
+    error, the "change.package.lot" component is tested in its own tests.
+    """
 
-    def _create_package_in_location(self, location, content):
-        """Create a package and quants in a location
-
-        content is a list of PackageContent
-        """
-        package = self.env["stock.quant.package"].create({})
-        for product, quantity, lot in content:
-            self._update_qty_in_location(
-                location, product, quantity, package=package, lot=lot
-            )
-        return package
-
-    def _create_lot(self, product):
-        return self.env["stock.production.lot"].create(
-            {"product_id": product.id, "company_id": self.env.company.id}
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        cls.batch = cls._create_picking_batch(
+            [[cls.BatchProduct(product=cls.product_a, quantity=10)]]
         )
 
     def _test_change_pack_lot(self, line, barcode, success=True, message=None):
@@ -57,61 +39,7 @@ class ClusterPickingChangePackLotCommon(ClusterPickingCommonCase):
                 next_state="change_pack_lot",
                 data=self._line_data(line),
             )
-
-    def _skip_line(self, line, next_line=None):
-        batch = line.picking_id.batch_id
-        response = self.service.dispatch(
-            "skip_line", params={"picking_batch_id": batch.id, "move_line_id": line.id}
-        )
-        if next_line:
-            self.assert_response(
-                response, next_state="start_line", data=self._line_data(next_line)
-            )
         return response
-
-    def assert_quant_reserved_qty(self, move_line, qty_func, package=None, lot=None):
-        domain = [
-            ("location_id", "=", move_line.location_id.id),
-            ("product_id", "=", move_line.product_id.id),
-        ]
-        if package:
-            domain.append(("package_id", "=", package.id))
-        if lot:
-            domain.append(("lot_id", "=", lot.id))
-        quant = self.env["stock.quant"].search(domain)
-        self.assertEqual(quant.reserved_quantity, qty_func())
-
-    def assert_quant_package_qty(self, location, package, qty_func):
-        quant = self.env["stock.quant"].search(
-            [("location_id", "=", location.id), ("package_id", "=", package.id)]
-        )
-        self.assertEqual(quant.quantity, qty_func())
-
-    def assert_control_stock_inventory(self, location, product, lot):
-        inventory = self.env["stock.inventory"].search([], order="id desc", limit=1)
-        self.assertRecordValues(
-            inventory,
-            [
-                {
-                    "state": "draft",
-                    "product_ids": product.ids,
-                    "name": "Pick: stock issue on lot: {} found in {}".format(
-                        lot.name, location.name
-                    ),
-                },
-            ],
-        )
-
-
-class ClusterPickingChangePackLotCase(ClusterPickingChangePackLotCommon):
-    """Tests covering the /change_pack_lot endpoint"""
-
-    @classmethod
-    def setUpClassBaseData(cls, *args, **kwargs):
-        super().setUpClassBaseData(*args, **kwargs)
-        cls.batch = cls._create_picking_batch(
-            [[cls.BatchProduct(product=cls.product_a, quantity=10)]]
-        )
 
     def test_change_pack_lot_change_pack_ok(self):
         initial_package = self._create_package_in_location(
@@ -135,137 +63,16 @@ class ClusterPickingChangePackLotCase(ClusterPickingChangePackLotCommon):
         )
 
         self.assertRecordValues(
-            line, [{"package_id": new_package.id, "result_package_id": new_package.id}]
-        )
-
-        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
-        # check that reservations have been updated
-        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
-        self.assert_quant_reserved_qty(
-            line, lambda: line.product_qty, package=new_package
-        )
-
-    def test_change_pack_lot_change_pack_different_location(self):
-        initial_package = self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)]
-        )
-
-        # initial_package from shelf1 will be selected in our move line
-        self._simulate_batch_selected(self.batch, fill_stock=False)
-
-        # put a package in shelf2 in the system, but we assume that in real,
-        # the operator put it in shelf1
-        new_package = self._create_package_in_location(
-            self.shelf2, [self.PackageContent(self.product_a, 10, lot=None)]
-        )
-
-        line = self.batch.picking_ids.move_line_ids
-        # when the operator wants to pick the initial package, in shelf1, the new
-        # package is in front of the other so they want to change the package
-        self._test_change_pack_lot(
-            line,
-            new_package.name,
-            success=True,
-            message=self.service.msg_store.package_replaced_by_package(
-                initial_package, new_package
-            ),
-        )
-
-        self.assertRecordValues(
-            line, [{"package_id": new_package.id, "result_package_id": new_package.id}]
-        )
-        self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
-        # check that reservations have been updated, the new package is not
-        # supposed to be in shelf2 anymore, and we should have no reserved qty
-        # for the initial package anymore
-        self.assert_quant_package_qty(self.shelf2, new_package, lambda: 0)
-        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
-        self.assert_quant_reserved_qty(
-            line, lambda: line.product_qty, package=new_package
-        )
-
-    def test_change_pack_lot_change_lot_in_package_ok(self):
-        self.product_a.tracking = "lot"
-        initial_lot = self._create_lot(self.product_a)
-        initial_package = self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
-        )
-        self._simulate_batch_selected(self.batch, fill_stock=False)
-        # ensure we have our new package in the same location
-        new_lot = self._create_lot(self.product_a)
-        new_package = self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=new_lot)]
-        )
-        line = self.batch.picking_ids.move_line_ids
-        self._test_change_pack_lot(
-            line,
-            new_lot.name,
-            success=True,
-            message=self.service.msg_store.package_replaced_by_package(
-                initial_package, new_package
-            ),
-        )
-
-        self.assertRecordValues(
             line,
             [
                 {
                     "package_id": new_package.id,
                     "result_package_id": new_package.id,
-                    "lot_id": new_lot.id,
+                    "product_qty": 10.0,
                 }
             ],
         )
         self.assertRecordValues(line.package_level_id, [{"package_id": new_package.id}])
-        # check that reservations have been updated
-        self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
-        self.assert_quant_reserved_qty(
-            line, lambda: line.product_qty, package=new_package
-        )
-
-    def test_change_pack_lot_change_lot_in_several_packages_error(self):
-        self.product_a.tracking = "lot"
-        initial_lot = self._create_lot(self.product_a)
-        self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
-        )
-        self._simulate_batch_selected(self.batch, fill_stock=False)
-        line = self.batch.picking_ids.move_line_ids
-        # create 2 packages for the same new lot in the same location
-        new_lot = self._create_lot(self.product_a)
-        self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, new_lot)]
-        )
-        self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, new_lot)]
-        )
-        self._test_change_pack_lot(
-            line,
-            new_lot.name,
-            success=False,
-            message=self.service.msg_store.several_packs_in_location(self.shelf1),
-        )
-
-    def test_change_pack_lot_change_lot_from_package_error(self):
-        # we shouldn't be allowed to replace a package by a lot
-        # if the lot is not a package in the quants (because we
-        # could then replace a package by a single unit)
-        self.product_a.tracking = "lot"
-        initial_lot = self._create_lot(self.product_a)
-        self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=initial_lot)]
-        )
-        self._simulate_batch_selected(self.batch, fill_stock=False)
-        line = self.batch.picking_ids.move_line_ids
-        # create a lot and put a unit in the location without package
-        new_lot = self._create_lot(self.product_a)
-        self._update_qty_in_location(self.shelf1, line.product_id, 1, lot=new_lot)
-        self._test_change_pack_lot(
-            line,
-            new_lot.name,
-            success=False,
-            message=self.service.msg_store.lot_is_not_a_package(new_lot),
-        )
 
     def test_change_pack_lot_change_lot_ok(self):
         initial_lot = self._create_lot(self.product_a)
@@ -282,226 +89,17 @@ class ClusterPickingChangePackLotCase(ClusterPickingChangePackLotCommon):
             success=True,
             message=self.service.msg_store.lot_replaced_by_lot(initial_lot, new_lot),
         )
-
         self.assertRecordValues(line, [{"lot_id": new_lot.id}])
-        # check that reservations have been updated
-        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
-        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
 
-    def test_change_pack_lot_change_lot_different_location_ok(self):
-        self.product_a.tracking = "lot"
+    def test_change_pack_lot_change_error(self):
         initial_lot = self._create_lot(self.product_a)
         self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=initial_lot)
         self._simulate_batch_selected(self.batch, fill_stock=False)
         line = self.batch.picking_ids.move_line_ids
-        new_lot = self._create_lot(self.product_a)
-        # ensure we have our new package in a different location
-        self._update_qty_in_location(self.shelf2, line.product_id, 10, lot=new_lot)
-        message = self.service.msg_store.lot_replaced_by_lot(initial_lot, new_lot)
-        message["body"] += " A draft inventory has been created for control."
-        self._test_change_pack_lot(
-            line, new_lot.name, success=True, message=message,
-        )
-
-        self.assertRecordValues(line, [{"lot_id": new_lot.id}])
-        # check that reservations have been updated
-        self.assert_quant_reserved_qty(line, lambda: 0, lot=initial_lot)
-        self.assert_quant_reserved_qty(line, lambda: line.product_qty, lot=new_lot)
-        self.assert_control_stock_inventory(self.shelf1, line.product_id, new_lot)
-
-
-class ClusterPickingChangePackLotCaseSpecial(ClusterPickingChangePackLotCommon):
-    """Tests covering the /change_pack_lot endpoint
-
-    Special cases where we use a custom batch transfer
-    """
-
-    def _create_picking_with_package_level(self, packages):
-        picking_form = Form(self.env["stock.picking"])
-        picking_form.partner_id = self.customer
-        picking_form.origin = "test"
-        picking_form.picking_type_id = self.picking_type
-        picking_form.location_id = self.stock_location
-        picking_form.location_dest_id = self.packing_location
-        for package in packages:
-            with picking_form.package_level_ids_details.new() as move:
-                move.package_id = package
-        picking = picking_form.save()
-        picking.action_confirm()
-        picking.action_assign()
-        return picking
-
-    def _create_batch_with_pickings(self, pickings):
-        batch_form = Form(self.env["stock.picking.batch"])
-        for picking in pickings:
-            batch_form.picking_ids.add(picking)
-        batch = batch_form.save()
-        return batch
-
-    def test_change_pack_lot_change_pack_different_content_error(self):
-        # create the initial package, that will be reserved first
-        initial_package = self._create_package_in_location(
-            self.shelf1,
-            [
-                self.PackageContent(self.product_a, 10, lot=None),
-                self.PackageContent(self.product_b, 10, lot=None),
-            ],
-        )
-        picking = self._create_picking_with_package_level(initial_package)
-        batch = self._create_batch_with_pickings(picking)
-        self._simulate_batch_selected(batch, fill_stock=False)
-
-        # create a new package in the same location
-        # with a different content
-        new_package = self._create_package_in_location(
-            self.shelf1,
-            [
-                self.PackageContent(self.product_a, 10, lot=None),
-                self.PackageContent(self.product_b, 8, lot=None),
-            ],
-        )
-
-        lines = batch.picking_ids.move_line_ids
-        # try to use the new package, which has a different content,
-        # not accepted
-        self._test_change_pack_lot(
-            lines[0],
-            new_package.name,
-            success=False,
-            message=self.service.msg_store.package_different_content(new_package),
-        )
-
-    def test_change_pack_lot_change_pack_multi_content_with_lot(self):
-        (self.product_a + self.product_b).tracking = "lot"
-        # create a package with 2 products tracked by lot, stored in shelf1
-        # this package is reserved first on the move line
-        initial_lot_a = self._create_lot(self.product_a)
-        initial_lot_b = self._create_lot(self.product_b)
-        initial_package = self._create_package_in_location(
-            self.shelf1,
-            [
-                self.PackageContent(self.product_a, 10, initial_lot_a),
-                self.PackageContent(self.product_b, 10, initial_lot_b),
-            ],
-        )
-
-        # create and reserve our transfer using the initial package
-        picking = self._create_picking_with_package_level(initial_package)
-        batch = self._create_batch_with_pickings(picking)
-        self._simulate_batch_selected(batch, fill_stock=False)
-
-        lines = picking.move_line_ids
-        package_level = lines.mapped("package_level_id")
-
-        # create a second package with the same content, which will be used
-        # as replacement
-        new_lot_a = self._create_lot(self.product_a)
-        new_lot_b = self._create_lot(self.product_b)
-        new_package = self._create_package_in_location(
-            self.shelf1,
-            [
-                self.PackageContent(self.product_a, 10, new_lot_a),
-                self.PackageContent(self.product_b, 10, new_lot_b),
-            ],
-        )
-        # changing the package of the first line will change all of them
-        self._test_change_pack_lot(
-            lines[0],
-            new_package.name,
-            success=True,
-            message=self.service.msg_store.package_replaced_by_package(
-                initial_package, new_package
-            ),
-        )
-
-        self.assertRecordValues(
-            lines,
-            [
-                {
-                    "package_id": new_package.id,
-                    "result_package_id": new_package.id,
-                    "lot_id": new_lot_a.id,
-                },
-                {
-                    "package_id": new_package.id,
-                    "result_package_id": new_package.id,
-                    "lot_id": new_lot_b.id,
-                },
-            ],
-        )
-
-        self.assertRecordValues(package_level, [{"package_id": new_package.id}])
-        # check that reservations have been updated
-        for line in lines:
-            self.assert_quant_reserved_qty(line, lambda: 0, package=initial_package)
-            self.assert_quant_reserved_qty(
-                line, lambda: line.product_qty, package=new_package
-            )
-
-    def test_change_pack_lot_change_pack_steal_from_other_move_line(self):
-        # create 2 picking, each with its own package
-        package1 = self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)],
-        )
-        picking1 = self._create_picking_with_package_level(package1)
-        self.assertEqual(picking1.move_line_ids.package_id, package1)
-
-        package2 = self._create_package_in_location(
-            self.shelf1, [self.PackageContent(self.product_a, 10, lot=None)],
-        )
-        picking2 = self._create_picking_with_package_level(package2)
-        self.assertEqual(picking2.move_line_ids.package_id, package2)
-
-        batch = self._create_batch_with_pickings(picking1 + picking2)
-        self._simulate_batch_selected(batch, fill_stock=False)
-
-        line = picking1.move_line_ids
-        # We "steal" package2 for the picking1
+        # ensure we have our new package in the same location
         self._test_change_pack_lot(
             line,
-            package2.name,
-            success=True,
-            message=self.service.msg_store.package_replaced_by_package(
-                package1, package2
-            ),
-        )
-
-        self.assertRecordValues(
-            picking1.move_line_ids,
-            [
-                {
-                    "package_id": package2.id,
-                    "result_package_id": package2.id,
-                    "state": "assigned",
-                }
-            ],
-        )
-        self.assertRecordValues(
-            picking2.move_line_ids,
-            [
-                {
-                    "package_id": package1.id,
-                    "result_package_id": package1.id,
-                    "state": "assigned",
-                }
-            ],
-        )
-        self.assertRecordValues(
-            picking1.package_level_ids,
-            [{"package_id": package2.id, "state": "assigned"}],
-        )
-        self.assertRecordValues(
-            picking2.package_level_ids,
-            [{"package_id": package1.id, "state": "assigned"}],
-        )
-        # check that reservations have been updated
-        self.assert_quant_reserved_qty(
-            picking1.move_line_ids,
-            lambda: picking1.move_line_ids.product_qty,
-            package=package2,
-        )
-        self.assert_quant_reserved_qty(
-            picking2.move_line_ids,
-            lambda: picking2.move_line_ids.product_qty,
-            package=package1,
+            "NOT_FOUND",
+            success=False,
+            message=self.service.msg_store.no_package_or_lot_for_barcode("NOT_FOUND"),
         )


### PR DESCRIPTION
The previous implementation suffered from several bugs or limitations,
mainly due to how the package levels were handled.

The new behavior when a user asks to change a package is:

* search for other lines that were moving the package, if the lines are
  not picked (qty_done > 0), unreserve them
* if the scanned package was not expected in the current location, make
  an inventory adjustment to fix it (as before)
* explode [0] the package level of the unreserved lines, otherwise, the next
  assign on them would try to reserve the same package again
* explode [0] the package level of the move line where we replace the
  package
* update the move line with the package, and update the move line with
  the same lot as the quant in the package if any
* if the available quantity in the quant of the package is lesser than
  the original quantity, update the move line quantity and run again
  "_action_assign" on the move that will generate a new move line for the
  remaining
* the call on _action_assign will also regenerate a package level for
  the move line (which will set the "result_package_id" to the same value)
  if the new package is entirely moved
* try to reserve again the lines previously unreserved

[0] delete the package level and set "result_package_id" to False on
    related move lines

The same way, changing a lot unreserve other lines using the same lot
if the whole quantity is reserved. If the quantity is partially
reserved, it only reduces the current quantity to the available (so
the user may do proceeds in 2 steps: take the available part, scan again
the lot which will unreserve the other lines).

When a lot is scanned but there is no known quant in the location, it
means there is an error in the inventory: add the quantity in odoo so
the user is not blocked, and create a control inventory to check.

Tests are moved to test case working only on the "change.package.lot"
component, the tests to change a package or lot in the services are kept
only for simple cases so we tests the responses for success or errors.




ref: 1498