### PR TITLE
Fix error when product has no default_code

### DIFF
--- a/shopfloor/services/schema.py
+++ b/shopfloor/services/schema.py
@@ -109,7 +109,7 @@ class BaseShopfloorSchemaResponse(Component):
             "id": {"required": True, "type": "integer"},
             "name": {"type": "string", "nullable": False, "required": True},
             "display_name": {"type": "string", "nullable": False, "required": True},
-            "default_code": {"type": "string", "nullable": False, "required": True},
+            "default_code": {"type": "string", "nullable": True, "required": True},
             "barcode": {"type": "string", "nullable": True, "required": False},
             "supplier_code": {"type": "string", "nullable": True, "required": False},
             "packaging": self._schema_list_of(self.packaging()),


### PR DESCRIPTION
The default code is not required on products.
When declared as non-nullable in the return schema, it makes the whole
request fail with a 500 error.