### PR TITLE
Location/Pack transfer: add option on menu to allow unreserving moves 

### DIFF
--- a/shopfloor/actions/__init__.py
+++ b/shopfloor/actions/__init__.py
@@ -25,3 +25,4 @@ from . import location_content_transfer_sorter
 from . import message
 from . import search
 from . import inventory
+from . import savepoint

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -355,6 +355,14 @@ class MessageAction(Component):
             ),
         }
 
+    def picking_already_started_in_location(self, pickings):
+        return {
+            "message_type": "error",
+            "body": _(
+                "Picking has already been started in this location in transfer(s): {}"
+            ).format(", ".join(pickings.mapped("name"))),
+        }
+
     def transfer_done_success(self, picking):
         return {
             "message_type": "success",

--- a/shopfloor/actions/savepoint.py
+++ b/shopfloor/actions/savepoint.py
@@ -1,0 +1,44 @@
+import uuid
+
+from psycopg2 import sql
+
+from odoo.sql_db import clear_env, flush_env
+
+from odoo.addons.component.core import Component
+
+
+class SavepointBuilder(Component):
+    """Return a new Savepoint instance"""
+
+    _name = "shopfloor.savepoint.action"
+    _inherit = "shopfloor.process.action"
+    _usage = "savepoint"
+
+    def new(self):
+        return Savepoint(self.env.cr)
+
+
+class Savepoint(object):
+    """Wrapper for SQL Savepoint
+
+    Close to "cr.savepoint()" context manager but this class gives more control
+    over when the release/rollback are called.
+    """
+
+    def __init__(self, cr):
+        self._cr = cr
+        self.name = uuid.uuid1().hex
+        flush_env(self._cr, clear=False)
+        self._execute("SAVEPOINT {}")
+
+    def rollback(self):
+        clear_env(self._cr)
+        self._execute("ROLLBACK TO SAVEPOINT {}")
+
+    def release(self):
+        flush_env(self._cr, clear=False)
+        self._execute("RELEASE SAVEPOINT {}")
+
+    def _execute(self, query):
+        # pylint: disable=sql-injection
+        self._cr.execute(sql.SQL(query).format(sql.Identifier(self.name)))

--- a/shopfloor/models/stock_package_level.py
+++ b/shopfloor/models/stock_package_level.py
@@ -27,3 +27,29 @@ class StockPackageLevel(models.Model):
                     line.owner_id = quant.owner_id
 
         self.package_id = new_package
+
+    def shallow_unlink(self):
+        """Unlink but keep the moves
+        A package level has a relation to "move_ids" only when the
+        package level was created first from the UI and it created
+        its move.
+        When we unlink a package level, it deletes the move it created.
+        But in some cases, we want to keep the move, e.g.:
+        * create a package level from the UI to move a package
+        * it generates a move for the matching product quantity
+        * we use a barcode scenario such as cluster or zone picking
+        * we use the "replace package" button
+        * when replacing the package, we have to delete the package level,
+          but we still have the same need in term of "I want X products",
+          so we have to keep the move
+        * another case is when we "dismiss" the package level in the location
+          content transfer scenario, we want to keep the "need" in moves, but
+          we are no longer moving the entire package level
+        """
+        self.move_ids.package_level_id = False
+        self.unlink()
+
+    def explode_package(self):
+        move_lines = self.move_line_ids
+        move_lines.result_package_id = False
+        self.shallow_unlink()

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -1,9 +1,4 @@
-import uuid
-
-from psycopg2 import sql
-
 from odoo import fields
-from odoo.sql_db import clear_env, flush_env
 
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
@@ -94,12 +89,7 @@ class SinglePackTransfer(Component):
         # Start a savepoint because we are may unreserve moves of other
         # picking types. If we do and we can't create a package level after,
         # we rollback to the initial state
-        savepoint_name = uuid.uuid1().hex
-        flush_env(self.env.cr, clear=False)
-        # pylint: disable=sql-injection
-        self.env.cr.execute(
-            sql.SQL("SAVEPOINT {}").format(sql.Identifier(savepoint_name))
-        )
+        savepoint = self.actions_for("savepoint").new()
         unreserved_moves = self.env["stock.move"].browse()
         if not package_level:
             other_move_lines = self.env["stock.move.line"].search(
@@ -136,13 +126,7 @@ class SinglePackTransfer(Component):
 
         if not package_level:
             # restore any unreserved move/package level
-            clear_env(self.env.cr)  # required to refresh cache data previous savepoint
-            # pylint: disable=sql-injection
-            self.env.cr.execute(
-                sql.SQL("ROLLBACK TO SAVEPOINT {}").format(
-                    sql.Identifier(savepoint_name)
-                )
-            )
+            savepoint.rollback()
             return self._response_for_start(
                 message=self.msg_store.no_pending_operation_for_pack(package)
             )
@@ -155,11 +139,7 @@ class SinglePackTransfer(Component):
 
         unreserved_moves._action_assign()
 
-        flush_env(self.env.cr, clear=False)
-        # pylint: disable=sql-injection
-        self.env.cr.execute(
-            sql.SQL("RELEASE SAVEPOINT {}").format(sql.Identifier(savepoint_name))
-        )
+        savepoint.release()
 
         return self._response_for_scan_location(package_level)
 

--- a/shopfloor/tests/test_single_pack_transfer_base.py
+++ b/shopfloor/tests/test_single_pack_transfer_base.py
@@ -1,0 +1,26 @@
+from .common import CommonCase
+
+
+class SinglePackTransferCommonBase(CommonCase):
+    @classmethod
+    def setUpClassVars(cls, *args, **kwargs):
+        super().setUpClassVars(*args, **kwargs)
+        cls.menu = cls.env.ref("shopfloor.shopfloor_menu_single_pallet_transfer")
+        cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
+        cls.wh = cls.profile.warehouse_id
+        cls.picking_type = cls.menu.picking_type_ids
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        # we activate the move creation in tests when needed
+        cls.menu.sudo().allow_move_create = False
+
+        # disable the completion on the picking type, we'll have specific test(s)
+        # to check the behavior of this screen
+        cls.picking_type.sudo().display_completion_info = False
+
+    def setUp(self):
+        super().setUp()
+        with self.work_on_services(menu=self.menu, profile=self.profile) as work:
+            self.service = work.component(usage="single_pack_transfer")

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -23,6 +23,11 @@
                     name="allow_move_create"
                     attrs="{'invisible': [('move_create_is_possible', '=', False)]}"
                 />
+                <field name="unreserve_other_moves_is_possible" invisible="1" />
+                <field
+                    name="allow_unreserve_other_moves"
+                    attrs="{'invisible': [('unreserve_other_moves_is_possible', '=', False)]}"
+                />
             </tree>
         </field>
     </record>
@@ -63,6 +68,16 @@
                         >
                             <field name="move_create_is_possible" invisible="1" />
                             <field name="allow_move_create" />
+                        </group>
+                        <group
+                            name="unreserve_other_moves"
+                            attrs="{'invisible': [('unreserve_other_moves_is_possible', '=', False)]}"
+                        >
+                            <field
+                                name="unreserve_other_moves_is_possible"
+                                invisible="1"
+                            />
+                            <field name="allow_unreserve_other_moves" />
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
When we scan a location or package which already have reserved move lines for other
picking types, and the option is active on the menu, unreserve the moves,
create new moves for the location content transfer and re-assign the
unreserved moves.

If one of the move that would be unreserved has already been picked
(qty_done > 0), an error is returned.
