### PR TITLE
Fix error with message being a dict, not str

### DIFF
--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -164,12 +164,12 @@ class Delivery(Component):
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
-            message = "\n".join(
+            message["body"] = "\n".join(
                 [
                     _("Package {} belongs to a picking without a valid state.").format(
                         package.name
                     ),
-                    message,
+                    message["body"],
                 ]
             )
             return self._response_for_deliver(message=message)
@@ -228,12 +228,12 @@ class Delivery(Component):
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
-            message = "\n".join(
+            message["body"] = "\n".join(
                 [
                     _("Product {} belongs to a picking without a valid state.").format(
                         product.name
                     ),
-                    message,
+                    message["body"],
                 ]
             )
             return self._response_for_deliver(message=message)
@@ -277,12 +277,12 @@ class Delivery(Component):
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
-            message = "\n".join(
+            message["body"] = "\n".join(
                 [
                     _("Lot {} belongs to a picking without a valid state.").format(
                         lot.name
                     ),
-                    message,
+                    message["body"],
                 ]
             )
             return self._response_for_deliver(message=message)


### PR DESCRIPTION
```
Traceback (most recent call last):
File "/odoo/external-src/wms-shopfloor/setup/shopfloor/odoo/addons/shopfloor/services/service.py", line 69, in _dispatch_with_db_logging result = super().dispatch(method_name, _id=_id, params=params)
File "/odoo/external-src/rest-framework/setup/base_rest/odoo/addons/base_rest/components/service.py", line 199, in dispatch res = func(**secure_params)
File "/odoo/external-src/wms-shopfloor/setup/shopfloor/odoo/addons/shopfloor/services/delivery.py", line 123, in scan_deliver return self._deliver_package(picking, package)
File "/odoo/external-src/wms-shopfloor/setup/shopfloor/odoo/addons/shopfloor/services/delivery.py", line 170, in _deliver_package message, TypeError: sequence item 1: expected str instance, dict found
```

The result of _check_picking_status is the full dict for a message
(message_type, body), so we have to update its body.