### PR TITLE
location content transfer: fix wrong return

### DIFF
--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -234,7 +234,7 @@ class LocationContentTransfer(Component):
             lambda line: line.picking_id.picking_type_id not in self.picking_types
         )
         if not lines_other_picking_types:
-            return (move_lines, None, None)
+            return (move_lines, self.env["stock.move"].browse(), None)
         unreserved_moves = move_lines.move_id
         location_move_lines = self.env["stock.move.line"].search(
             self._find_location_all_move_lines_domain(location)


### PR DESCRIPTION
The caller expects a recordset of moves in the second item of the tuple.

ref: 1721