### PR TITLE
pack/location transfer: add option to ignore transfers when no putaway is available

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -227,6 +227,12 @@ class MessageAction(Component):
             "body": _("No pending operation for package %s.") % pack.name,
         }
 
+    def no_putaway_destination_available(self):
+        return {
+            "message_type": "error",
+            "body": _("No putaway destination is available."),
+        }
+
     def unrecoverable_error(self):
         return {
             "message_type": "error",

--- a/shopfloor/migrations/13.0.1.2.0/post-migration.py
+++ b/shopfloor/migrations/13.0.1.2.0/post-migration.py
@@ -43,7 +43,9 @@ def _compute_logs_new_values(env):
             else:
                 new_vals[fname] = json.dumps(val, indent=4, sort_keys=True)
         if entry.error and not entry.exception_name:
-            new_vals.update(_get_exception_details(entry))
+            exception_details = _get_exception_details(entry)
+            if exception_details:
+                new_vals.update(exception_details)
         entry.write(new_vals)
 
 

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -354,6 +354,16 @@ class LocationContentTransfer(Component):
             pickings = new_moves.mapped("picking_id")
             move_lines = new_moves.move_line_ids
 
+        if self.work.menu.ignore_no_putaway_available and self._no_putaway_available(
+            move_lines
+        ):
+            # the putaway created a move line but no putaway was possible, so revert
+            # to the initial state
+            savepoint.rollback()
+            return self._response_for_start(
+                message=self.msg_store.no_putaway_destination_available()
+            )
+
         if not pickings:
             return self._response_for_start(
                 message=self.msg_store.location_empty(location)
@@ -370,6 +380,12 @@ class LocationContentTransfer(Component):
         savepoint.release()
 
         return self._router_single_or_all_destination(pickings)
+
+    def _no_putaway_available(self, move_lines):
+        base_locations = self.picking_types.default_location_dest_id
+        # when no putaway is found, the move line destination stays the
+        # default's of the picking type
+        return any(line.location_dest_id in base_locations for line in move_lines)
 
     def _find_transfer_move_lines_domain(self, location):
         return [

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_actions_change_package_lot
 from . import test_actions_data
 from . import test_actions_data_detail
 from . import test_single_pack_transfer
+from . import test_single_pack_transfer_putaway
 from . import test_cluster_picking_base
 from . import test_cluster_picking_batch
 from . import test_cluster_picking_select

--- a/shopfloor/tests/test_location_content_transfer_putaway.py
+++ b/shopfloor/tests/test_location_content_transfer_putaway.py
@@ -1,0 +1,104 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .test_location_content_transfer_base import LocationContentTransferCommonCase
+
+
+class TestLocationContentTransferPutaway(LocationContentTransferCommonCase):
+    """Tests with putaway when using option to ignore unavailable putaway locations
+    """
+
+    @classmethod
+    def setUpClassVars(cls, *args, **kwargs):
+        super().setUpClassVars(*args, **kwargs)
+        cls.pallets_storage_type = cls.env.ref(
+            "stock_storage_type.package_storage_type_pallets"
+        )
+        cls.main_pallets_location = cls.env.ref(
+            "stock_storage_type.stock_location_pallets"
+        )
+        cls.reserve_pallets_locations = cls.env.ref(
+            "stock_storage_type.stock_location_pallets_reserve"
+        )
+        cls.all_pallets_locations = (
+            cls.main_pallets_location.leaf_location_ids
+            | cls.reserve_pallets_locations.leaf_location_ids
+        )
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        cls.package = cls.env["stock.quant.package"].create(
+            {
+                # this will parameterize the putaway to use pallet locations,
+                # and if not, it will stay on the picking type's default dest.
+                "package_storage_type_id": cls.pallets_storage_type.id,
+            }
+        )
+        cls.package2 = cls.env["stock.quant.package"].create(
+            {
+                # this will parameterize the putaway to use pallet locations,
+                # and if not, it will stay on the picking type's default dest.
+                "package_storage_type_id": cls.pallets_storage_type.id,
+            }
+        )
+        # create a location to be sure it's empty
+        cls.test_loc = (
+            cls.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "location_id": cls.stock_location.id,
+                    "name": "test",
+                    "barcode": "test_loc",
+                }
+            )
+        )
+        cls._update_qty_in_location(
+            cls.test_loc, cls.product_a, 10, package=cls.package
+        )
+        cls._update_qty_in_location(
+            cls.test_loc, cls.product_a, 10, package=cls.package2
+        )
+        cls.menu.sudo().allow_move_create = True
+        cls.menu.sudo().ignore_no_putaway_available = True
+        cls.menu.sudo().allow_unreserve_other_moves = True
+
+    def test_normal_putaway(self):
+        """Ensure putaway is applied on moves"""
+        response = self.service.dispatch(
+            "scan_location", params={"barcode": self.test_loc.barcode}
+        )
+        self.assert_response(
+            response, next_state="start_single", data=self.ANY,
+        )
+        package_level_id = response["data"]["start_single"]["package_level"]["id"]
+        package_level = self.env["stock.package_level"].browse(package_level_id)
+        self.assertIn(package_level.location_dest_id, self.all_pallets_locations)
+
+    def test_ignore_no_putaway_available(self):
+        """Ignore no putaway available is activated on the menu
+
+        In this case, when no putaway is possible, the changes
+        are rollbacked and an error is returned.
+        """
+        for location in self.all_pallets_locations:
+            package = self.env["stock.quant.package"].create(
+                {"package_storage_type_id": self.pallets_storage_type.id}
+            )
+            self._update_qty_in_location(location, self.product_a, 10, package=package)
+
+        response = self.service.dispatch(
+            "scan_location", params={"barcode": self.test_loc.barcode}
+        )
+        self.assert_response(
+            response,
+            next_state="start",
+            message=self.service.msg_store.no_putaway_destination_available(),
+        )
+
+        package_levels = self.env["stock.package_level"].search(
+            [("package_id", "in", (self.package.id, self.package2.id))]
+        )
+        # no package level created to move the package
+        self.assertFalse(package_levels)

--- a/shopfloor/tests/test_location_content_transfer_start.py
+++ b/shopfloor/tests/test_location_content_transfer_start.py
@@ -4,7 +4,7 @@
 from .test_location_content_transfer_base import LocationContentTransferCommonCase
 
 
-class LocationContentTransferStartCase(LocationContentTransferCommonCase):
+class TestLocationContentTransferStart(LocationContentTransferCommonCase):
     """Tests for start state and recover
 
     Endpoints:

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -7,7 +7,7 @@ from odoo.tests.common import Form
 from .test_single_pack_transfer_base import SinglePackTransferCommonBase
 
 
-class SinglePackTransferCase(SinglePackTransferCommonBase):
+class TestSinglePackTransfer(SinglePackTransferCommonBase):
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):
         super().setUpClassBaseData(*args, **kwargs)

--- a/shopfloor/tests/test_single_pack_transfer_putaway.py
+++ b/shopfloor/tests/test_single_pack_transfer_putaway.py
@@ -1,0 +1,76 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .test_single_pack_transfer_base import SinglePackTransferCommonBase
+
+
+class TestSinglePackTransferPutaway(SinglePackTransferCommonBase):
+    @classmethod
+    def setUpClassVars(cls, *args, **kwargs):
+        super().setUpClassVars(*args, **kwargs)
+        cls.pallets_storage_type = cls.env.ref(
+            "stock_storage_type.package_storage_type_pallets"
+        )
+        cls.main_pallets_location = cls.env.ref(
+            "stock_storage_type.stock_location_pallets"
+        )
+        cls.reserve_pallets_locations = cls.env.ref(
+            "stock_storage_type.stock_location_pallets_reserve"
+        )
+        cls.all_pallets_locations = (
+            cls.main_pallets_location.leaf_location_ids
+            | cls.reserve_pallets_locations.leaf_location_ids
+        )
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        cls.package = cls.env["stock.quant.package"].create(
+            {
+                # this will parameterize the putaway to use pallet locations,
+                # and if not, it will stay on the picking type's default dest.
+                "package_storage_type_id": cls.pallets_storage_type.id,
+            }
+        )
+        cls._update_qty_in_location(cls.shelf1, cls.product_a, 10, package=cls.package)
+        cls.menu.sudo().ignore_no_putaway_available = True
+        cls.menu.sudo().allow_move_create = True
+
+    def test_normal_putaway(self):
+        """Ensure putaway is applied on moves"""
+        response = self.service.dispatch(
+            "start", params={"barcode": self.shelf1.barcode}
+        )
+        self.assert_response(
+            response, next_state="scan_location", data=self.ANY,
+        )
+        package_level_id = response["data"]["scan_location"]["id"]
+        package_level = self.env["stock.package_level"].browse(package_level_id)
+        self.assertIn(package_level.location_dest_id, self.all_pallets_locations)
+
+    def test_ignore_no_putaway_available(self):
+        """Ignore no putaway available is activated on the menu
+
+        In this case, when no putaway is possible, the changes
+        are rollbacked and an error is returned.
+        """
+        for location in self.all_pallets_locations:
+            package = self.env["stock.quant.package"].create(
+                {"package_storage_type_id": self.pallets_storage_type.id}
+            )
+            self._update_qty_in_location(location, self.product_a, 10, package=package)
+
+        response = self.service.dispatch(
+            "start", params={"barcode": self.shelf1.barcode}
+        )
+        self.assert_response(
+            response,
+            next_state="start",
+            message=self.service.msg_store.no_putaway_destination_available(),
+        )
+
+        package_levels = self.env["stock.package_level"].search(
+            [("package_id", "=", self.package.id)]
+        )
+        # no package level created to move the package
+        self.assertFalse(package_levels)

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -28,6 +28,11 @@
                     name="allow_unreserve_other_moves"
                     attrs="{'invisible': [('unreserve_other_moves_is_possible', '=', False)]}"
                 />
+                <field name="ignore_no_putaway_available_is_possible" invisible="1" />
+                <field
+                    name="ignore_no_putaway_available"
+                    attrs="{'invisible': [('ignore_no_putaway_available_is_possible', '=', False)]}"
+                />
             </tree>
         </field>
     </record>
@@ -78,6 +83,16 @@
                                 invisible="1"
                             />
                             <field name="allow_unreserve_other_moves" />
+                        </group>
+                        <group
+                            name="ignore_no_putaway_available"
+                            attrs="{'invisible': [('ignore_no_putaway_available_is_possible', '=', False)]}"
+                        >
+                            <field
+                                name="ignore_no_putaway_available_is_possible"
+                                invisible="1"
+                            />
+                            <field name="ignore_no_putaway_available" />
                         </group>
                     </group>
                 </sheet>

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -4,7 +4,7 @@
         <field name="name">shopfloor menu tree</field>
         <field name="model">shopfloor.menu</field>
         <field name="arch" type="xml">
-            <tree editable="bottom">
+            <tree>
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="scenario" />
@@ -17,21 +17,6 @@
                     name="picking_type_ids"
                     widget="many2many_tags"
                     options="{'no_create': 1}"
-                />
-                <field name="move_create_is_possible" invisible="1" />
-                <field
-                    name="allow_move_create"
-                    attrs="{'invisible': [('move_create_is_possible', '=', False)]}"
-                />
-                <field name="unreserve_other_moves_is_possible" invisible="1" />
-                <field
-                    name="allow_unreserve_other_moves"
-                    attrs="{'invisible': [('unreserve_other_moves_is_possible', '=', False)]}"
-                />
-                <field name="ignore_no_putaway_available_is_possible" invisible="1" />
-                <field
-                    name="ignore_no_putaway_available"
-                    attrs="{'invisible': [('ignore_no_putaway_available_is_possible', '=', False)]}"
                 />
             </tree>
         </field>

--- a/shopfloor_batch_automatic_creation/views/shopfloor_menu_views.xml
+++ b/shopfloor_batch_automatic_creation/views/shopfloor_menu_views.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="shopfloor_menu_tree_view" model="ir.ui.view">
-        <field name="name">shopfloor menu tree</field>
-        <field name="model">shopfloor.menu</field>
-        <field name="inherit_id" ref="shopfloor.shopfloor_menu_tree_view" />
-        <field name="arch" type="xml">
-            <xpath expr="//tree" position="attributes">
-                <attribute name="editable" />
-            </xpath>
-        </field>
-    </record>
     <record id="shopfloor_menu_form_view" model="ir.ui.view">
         <field name="name">shopfloor menu form</field>
         <field name="model">shopfloor.menu</field>


### PR DESCRIPTION
When we start a single pack or location content transfer, the moves (created or not by the
menu) are assigned. When we use this menu with putaways, we can
activate the option "ignore no putaway available".

When no putaway location is available, the destination location
remains the default one. If this option is active and the destination
location didn't change: rollback the action_assign. This will prevent
having move lines for things we don't know where to place.

The user gets a message that the package/content couldn't get a put-away, and will have to retry later.

ref: 1720