### PR TITLE
location transfer: allow to scan source package on lines

### DIFF
--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -575,6 +575,13 @@ class LocationContentTransfer(Component):
             )
 
         search = self.actions_for("search")
+
+        package = search.package_from_scan(barcode)
+        if package and move_line.package_id == package:
+            # In case we have a source package but no package level because if
+            # we have a package level, we would use "scan_package".
+            return self._response_for_scan_destination(location, move_line)
+
         product = search.product_from_scan(barcode)
         if product and product == move_line.product_id:
             if product.tracking in ("lot", "serial"):

--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -231,6 +231,11 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         )
         self.assert_response_scan_destination(response, move_line)
 
+    def test_scan_line_package_ok(self):
+        move_line = self.picking2.move_line_ids[0]
+        package = move_line.package_id = self.env["stock.quant.package"].create({})
+        self._test_scan_line_ok(move_line, package.name)
+
     def test_scan_line_product_ok(self):
         move_line = self.picking2.move_line_ids[0]
         # check we selected the good line


### PR DESCRIPTION
When move lines have no package level (e.g. we use the "Open Package"
button), they still have the package in "package_id".
Users should be able to scan this package to identify that they
want to take the products from there (they may have no label on
products).