### PR TITLE
[14.0] Shopfloor mobile base auth api key - move logic to handler

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -51,7 +51,7 @@ export var LoginPage = Vue.component("login-page", {
             return name;
         },
         _handle_invalid_login() {
-            this.error = this.$t("screen.login.error.login_invalid");
+            this.error = this.$root.$t("screen.login.error.login_invalid");
         },
     },
     template: `

--- a/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
@@ -3,6 +3,7 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
+import {translation_registry} from "/shopfloor_mobile_base/static/wms/src/services/translation_registry.js";
 import {
     AuthHandlerMixin,
     auth_handler_registry,
@@ -21,7 +22,17 @@ export class ApiKeyAuthHandler extends AuthHandlerMixin {
             },
         };
     }
+
+    // on_login($root, evt, data) {
+    // No need for a handler as we set the api_key inside the login method
+    // }
+
+    // on_logout($root) {
+    // No need for a handler as the reset_on_clear flag in the config_registry
+    // is going to flush the api_key on appdata cleanup
+    // }
 }
+
 auth_handler_registry.add(new ApiKeyAuthHandler("api_key"));
 
 /**
@@ -32,33 +43,13 @@ auth_handler_registry.add(new ApiKeyAuthHandler("api_key"));
 Vue.component("login-api_key", {
     data: function () {
         return {
-            error: "",
             apikey: "",
         };
     },
     methods: {
         login: function (evt) {
-            evt.preventDefault();
-            // Call odoo application load => set the result in the local storage in json
-            this.$parent.error = "";
             this.$root.apikey = this.apikey;
-            this.$root
-                ._loadConfig()
-                .catch((error) => {
-                    this._handle_invalid_key();
-                })
-                .then(() => {
-                    // TODO: shall we do this in $root._loadRoutes?
-                    if (this.$root.is_authenticated()) {
-                        this.$router.push({name: "home"});
-                    } else {
-                        this._handle_invalid_key();
-                    }
-                });
-        },
-        _handle_invalid_key() {
-            this.error = this.$t("screen.login.error.api_key_invalid");
-            this.$root.apikey = "";
+            this.$root.login(evt);
         },
     },
     template: `
@@ -81,8 +72,13 @@ Vue.component("login-api_key", {
     `,
 });
 
-// TODO: Add translation
-// login: {
-//     api_key_placeholder: "YOUR_API_KEY_HERE",
-//     api_key_label: "API key",
-// },
+translation_registry.add("en-US.screen.login.api_key_label", "API key");
+translation_registry.add("fr-FR.screen.login.api_key_label", "Clé API");
+translation_registry.add("de-DE.screen.login.api_key_label", "API-Schlüssel");
+
+translation_registry.add("en-US.screen.login.api_key_placeholder", "YOUR_API_KEY_HERE");
+translation_registry.add("fr-FR.screen.login.api_key_placeholder", "VOTRE_CLE_API_ICI");
+translation_registry.add(
+    "de-DE.screen.login.api_key_placeholder",
+    "DEIN_API-SCHLÜSSEL_HIER"
+);

--- a/shopfloor_mobile_base_auth_user/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_user/static/wms/src/login.js
@@ -4,6 +4,7 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
+import {translation_registry} from "/shopfloor_mobile_base/static/wms/src/services/translation_registry.js";
 import {
     AuthHandlerMixin,
     auth_handler_registry,
@@ -27,7 +28,6 @@ export class UserAuthHandler extends AuthHandlerMixin {
     }
 
     on_login($root, evt, data) {
-        const self = this;
         evt.preventDefault();
         // Call odoo application load => set the result in the local storage in json
         const odoo = $root.getOdoo({base_url: "/session/"});
@@ -36,9 +36,6 @@ export class UserAuthHandler extends AuthHandlerMixin {
             .post("auth/login", data, true)
             .then(function (response) {
                 if (response.error) {
-                    // If there is a need to handle different login error messages
-                    // depending on the response, pass the error as an argument
-                    // to def.reject
                     return def.reject();
                 }
                 return def.resolve();
@@ -108,3 +105,11 @@ Vue.component("login-user", {
     </v-form>
     `,
 });
+
+translation_registry.add("en-US.screen.login.username", "Username");
+translation_registry.add("fr-FR.screen.login.username", "Nom d'utilisateur");
+translation_registry.add("de-DE.screen.login.username", "Benutzername");
+
+translation_registry.add("en-US.screen.login.password", "Password");
+translation_registry.add("fr-FR.screen.login.password", "Mot de passe");
+translation_registry.add("de-DE.screen.login.password", "Passwort");


### PR DESCRIPTION
Refactor to move the api_key logic logic to the handler:

- Add on_login and on_logout methods in the api_key handler.
- Refactor _on_login method in $root.
- Refactor handling of different error messages depending on auth type. 