### PR TITLE
onchange speedup

### DIFF
--- a/sale_stock_available_to_promise_release_block/models/sale_order_line.py
+++ b/sale_stock_available_to_promise_release_block/models/sale_order_line.py
@@ -18,6 +18,7 @@ class SaleOrderLine(models.Model):
         compute="_compute_release_blocked_label",
     )
 
+    @api.depends("move_ids.release_blocked")
     def _compute_is_release_blocked(self):
         for rec in self:
             rec.is_release_blocked = any(rec.move_ids.mapped("release_blocked"))
@@ -30,7 +31,7 @@ class SaleOrderLine(models.Model):
     @api.depends("is_release_blocked")
     def _compute_release_blocked_label(self):
         for rec in self:
-            rec.release_blocked_label = _("Blocked") if rec.is_release_blocked else ""
+            rec.release_blocked_label = _("Blocked") if rec.is_release_blocked else False
 
     def _prepare_procurement_values(self, group_id=False):
         vals = super()._prepare_procurement_values(group_id=group_id)


### PR DESCRIPTION
* declare a dependency on the sale.order.line `is_release_blocked` field to avoid systematic recomputation
* clean the `release_blocked_label` by setting it to `False` instead of an empty string: this way the field does not show up in the diff when odoo compares lines in an onchange